### PR TITLE
Fix image alt text on Maker Lab website

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -324,6 +324,42 @@ img {
   transform: scale(1.1);
 }
 
+/* Image Gallery Wrapper - for multiple images in a grid */
+.image-gallery-wrapper {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  gap: 20px;
+  margin: var(--spacing-lg) 0;
+}
+
+.image-gallery-wrapper img {
+  width: 100%;
+  height: auto;
+  object-fit: cover;
+  border-radius: 8px;
+  box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+
+.image-gallery-wrapper img:hover {
+  transform: translateY(-5px);
+  box-shadow: 0 5px 20px rgba(0,0,0,0.15);
+}
+
+/* Responsive adjustments for image galleries */
+@media (max-width: 768px) {
+  .image-gallery-wrapper {
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    gap: var(--spacing-sm);
+  }
+}
+
+@media (max-width: 480px) {
+  .image-gallery-wrapper {
+    grid-template-columns: 1fr;
+  }
+}
+
 /* Blog */
 .blog-post {
   background-color: var(--white);

--- a/lab-staff.html
+++ b/lab-staff.html
@@ -70,13 +70,13 @@
 
 <div class="image-gallery-wrapper">
 
-  
-   <img src="https://images.squarespace-cdn.com/content/v1/59ebf554edaed825d0d8e200/1509732301296-8334AH1OFX71HUFLSQ2C/aric.jpeg?format=original" />
-  
 
-  
-   <img src="https://images.squarespace-cdn.com/content/v1/59ebf554edaed825d0d8e200/1509732334287-2C67XT6IWTLWUBO2X4DR/vishal_small.png?format=original" />
-  
+   <img src="https://images.squarespace-cdn.com/content/v1/59ebf554edaed825d0d8e200/1509732301296-8334AH1OFX71HUFLSQ2C/aric.jpeg?format=original" alt="Dr. Aric Rindfleisch - Faculty member and Executive Director of Illinois MakerLab" />
+
+
+
+   <img src="https://images.squarespace-cdn.com/content/v1/59ebf554edaed825d0d8e200/1509732334287-2C67XT6IWTLWUBO2X4DR/vishal_small.png?format=original" alt="Dr. Vishal Sachdev - Faculty member and Director of Illinois MakerLab" />
+
 
 </div>
 
@@ -113,25 +113,25 @@
 
 <div class="image-gallery-wrapper">
 
-  
-   <img src="https://images.squarespace-cdn.com/content/v1/59ebf554edaed825d0d8e200/1509732563190-6Z4AN9GSC6YHBVCJ09UB/ErwinCruz_ProfilePic_2012April17.jpg?format=original" />
-  
 
-  
-   <img src="https://images.squarespace-cdn.com/content/v1/59ebf554edaed825d0d8e200/1509732598672-181JGIYCQ5LZXYBI5LC8/zach.jpg?format=original" />
-  
+   <img src="https://images.squarespace-cdn.com/content/v1/59ebf554edaed825d0d8e200/1509732563190-6Z4AN9GSC6YHBVCJ09UB/ErwinCruz_ProfilePic_2012April17.jpg?format=original" alt="Erwin Cruz - Advisory Board Member" />
 
-  
-   <img src="https://images.squarespace-cdn.com/content/v1/59ebf554edaed825d0d8e200/1509732643284-X380HY092ZN2YOYWPSJK/LAUREN6.jpeg?format=original" />
-  
 
-  
-   <img src="https://images.squarespace-cdn.com/content/v1/59ebf554edaed825d0d8e200/1509732652249-X0JZ1BEW8ARS36VDDR6Q/mattgriffin.png?format=original" />
-  
 
-  
-   <img src="https://images.squarespace-cdn.com/content/v1/59ebf554edaed825d0d8e200/1509732684790-VYKWY8MF83Q79ETRN6QD/John-Hornick.jpeg?format=original" />
-  
+   <img src="https://images.squarespace-cdn.com/content/v1/59ebf554edaed825d0d8e200/1509732598672-181JGIYCQ5LZXYBI5LC8/zach.jpg?format=original" alt="Zach Kaplan - Advisory Board Member" />
+
+
+
+   <img src="https://images.squarespace-cdn.com/content/v1/59ebf554edaed825d0d8e200/1509732643284-X380HY092ZN2YOYWPSJK/LAUREN6.jpeg?format=original" alt="Lauren - Advisory Board Member" />
+
+
+
+   <img src="https://images.squarespace-cdn.com/content/v1/59ebf554edaed825d0d8e200/1509732652249-X0JZ1BEW8ARS36VDDR6Q/mattgriffin.png?format=original" alt="Matt Griffin - Advisory Board Member" />
+
+
+
+   <img src="https://images.squarespace-cdn.com/content/v1/59ebf554edaed825d0d8e200/1509732684790-VYKWY8MF83Q79ETRN6QD/John-Hornick.jpeg?format=original" alt="John Hornick - Advisory Board Member" />
+
 
 </div>
 
@@ -197,8 +197,8 @@
 
 
 
-  
-      <img src="https://images.squarespace-cdn.com/content/v1/59ebf554edaed825d0d8e200/1602872653955-8NC9KY3KG16MBGSWVRUY/DSC02261+%282%29.JPG?format=original" alt=""/>
+
+      <img src="https://images.squarespace-cdn.com/content/v1/59ebf554edaed825d0d8e200/1602872653955-8NC9KY3KG16MBGSWVRUY/DSC02261+%282%29.JPG?format=original" alt="Shirley Shah - Lab Guru and Designer" />
   
 
 

--- a/partners.html
+++ b/partners.html
@@ -70,13 +70,13 @@
 
 <div class="image-gallery-wrapper">
 
-  
-   <img src="https://images.squarespace-cdn.com/content/v1/59ebf554edaed825d0d8e200/1509695527362-4LCFUAAG7MS4JLR5KADU/All+new+Ultimaker+2+printers+in+the+MakerLab.jpg?format=original" />
-  
 
-  
-   <img src="https://images.squarespace-cdn.com/content/v1/59ebf554edaed825d0d8e200/1509695557515-6971L89HY2RE6VDQ4QDN/Dual+Color+Ultimaker+3+Printers.jpg?format=original" />
-  
+   <img src="https://images.squarespace-cdn.com/content/v1/59ebf554edaed825d0d8e200/1509695527362-4LCFUAAG7MS4JLR5KADU/All+new+Ultimaker+2+printers+in+the+MakerLab.jpg?format=original" alt="All new Ultimaker 2 printers in the MakerLab" />
+
+
+
+   <img src="https://images.squarespace-cdn.com/content/v1/59ebf554edaed825d0d8e200/1509695557515-6971L89HY2RE6VDQ4QDN/Dual+Color+Ultimaker+3+Printers.jpg?format=original" alt="Dual Color Ultimaker 3 Printers" />
+
 
 </div>
 

--- a/pricingservices.html
+++ b/pricingservices.html
@@ -40,21 +40,21 @@
           <h1>What We Offer</h1>
           <div class="image-gallery-wrapper">
 
-  
-   <img src="https://images.squarespace-cdn.com/content/v1/59ebf554edaed825d0d8e200/1509732893164-U175RD5MD1UEGHNQSQ8M/Carabiners.jpg?format=original" />
-  
 
-  
-   <img src="https://images.squarespace-cdn.com/content/v1/59ebf554edaed825d0d8e200/1509732885371-2E3CLYG5AJ1EDJKH5V3L/Ribs-2.jpg?format=original" />
-  
+   <img src="https://images.squarespace-cdn.com/content/v1/59ebf554edaed825d0d8e200/1509732893164-U175RD5MD1UEGHNQSQ8M/Carabiners.jpg?format=original" alt="3D printed carabiners demonstration" />
 
-  
-   <img src="https://images.squarespace-cdn.com/content/v1/59ebf554edaed825d0d8e200/1509732906289-NWP3ZF8BOVH9ZXO6KCYL/Build+Max-9.jpg?format=original" />
-  
 
-  
-   <img src="https://images.squarespace-cdn.com/content/v1/59ebf554edaed825d0d8e200/1509732910544-XOAXXWVXOVSF8Z9YNQHI/Dual+Printing.jpg?format=original" />
-  
+
+   <img src="https://images.squarespace-cdn.com/content/v1/59ebf554edaed825d0d8e200/1509732885371-2E3CLYG5AJ1EDJKH5V3L/Ribs-2.jpg?format=original" alt="3D printed anatomical rib model" />
+
+
+
+   <img src="https://images.squarespace-cdn.com/content/v1/59ebf554edaed825d0d8e200/1509732906289-NWP3ZF8BOVH9ZXO6KCYL/Build+Max-9.jpg?format=original" alt="Building and assembling 3D printed projects" />
+
+
+
+   <img src="https://images.squarespace-cdn.com/content/v1/59ebf554edaed825d0d8e200/1509732910544-XOAXXWVXOVSF8Z9YNQHI/Dual+Printing.jpg?format=original" alt="Dual color 3D printing in progress" />
+
 
 </div>
 

--- a/resources.html
+++ b/resources.html
@@ -67,41 +67,41 @@
 
 <div class="image-gallery-wrapper">
 
-  
-   <img src="https://images.squarespace-cdn.com/content/v1/59ebf554edaed825d0d8e200/1509659095704-EPXOMO97R4Q4Z0E3Y127/Racing-Glove.jpg?format=original" />
-  
 
-  
-   <img src="https://images.squarespace-cdn.com/content/v1/59ebf554edaed825d0d8e200/1509659103420-OA7FWOVG282B5FTK6U1M/Digital-Making-Week-10-2.jpg?format=original" />
-  
+   <img src="https://images.squarespace-cdn.com/content/v1/59ebf554edaed825d0d8e200/1509659095704-EPXOMO97R4Q4Z0E3Y127/Racing-Glove.jpg?format=original" alt="3D printed racing glove prototype" />
 
-  
-   <img src="https://images.squarespace-cdn.com/content/v1/59ebf554edaed825d0d8e200/1509659115885-MCUGPD2MZXU17ZT7GOAA/Minecraft-3D-Printing.jpg?format=original" />
-  
 
-  
-   <img src="https://images.squarespace-cdn.com/content/v1/59ebf554edaed825d0d8e200/1509659134445-UUOF9SMLATB1HJI59354/Thinking-Man-e1487973011282.jpg?format=original" />
-  
 
-  
-   <img src="https://images.squarespace-cdn.com/content/v1/59ebf554edaed825d0d8e200/1509659140138-UXYDNF825T3IVKVOGYSM/Mini-Figures.jpg?format=original" />
-  
+   <img src="https://images.squarespace-cdn.com/content/v1/59ebf554edaed825d0d8e200/1509659103420-OA7FWOVG282B5FTK6U1M/Digital-Making-Week-10-2.jpg?format=original" alt="Digital making workshop project examples" />
 
-  
-   <img src="https://images.squarespace-cdn.com/content/v1/59ebf554edaed825d0d8e200/1509659191681-WYL2C31RO64I1AYYWLEV/Valentines-Day-3.jpg?format=original" />
-  
 
-  
-   <img src="https://images.squarespace-cdn.com/content/v1/59ebf554edaed825d0d8e200/1509659208332-IO9DE6ZJ5MK6VSIAGHGO/Valentines-Day-2.jpg?format=original" />
-  
 
-  
-   <img src="https://images.squarespace-cdn.com/content/v1/59ebf554edaed825d0d8e200/1509659214026-74JF7RU98DUFSRM4QZWF/Hippo.jpg?format=original" />
-  
+   <img src="https://images.squarespace-cdn.com/content/v1/59ebf554edaed825d0d8e200/1509659115885-MCUGPD2MZXU17ZT7GOAA/Minecraft-3D-Printing.jpg?format=original" alt="3D printed Minecraft characters" />
 
-  
-   <img src="https://images.squarespace-cdn.com/content/v1/59ebf554edaed825d0d8e200/1509659220097-L3YQ51ZF5RGP9EYTJSKC/Build-Max-10.jpg?format=original" />
-  
+
+
+   <img src="https://images.squarespace-cdn.com/content/v1/59ebf554edaed825d0d8e200/1509659134445-UUOF9SMLATB1HJI59354/Thinking-Man-e1487973011282.jpg?format=original" alt="3D printed sculpture of The Thinker" />
+
+
+
+   <img src="https://images.squarespace-cdn.com/content/v1/59ebf554edaed825d0d8e200/1509659140138-UXYDNF825T3IVKVOGYSM/Mini-Figures.jpg?format=original" alt="Collection of 3D printed mini figures" />
+
+
+
+   <img src="https://images.squarespace-cdn.com/content/v1/59ebf554edaed825d0d8e200/1509659191681-WYL2C31RO64I1AYYWLEV/Valentines-Day-3.jpg?format=original" alt="3D printed Valentine's Day heart designs" />
+
+
+
+   <img src="https://images.squarespace-cdn.com/content/v1/59ebf554edaed825d0d8e200/1509659208332-IO9DE6ZJ5MK6VSIAGHGO/Valentines-Day-2.jpg?format=original" alt="3D printed Valentine's Day decorations" />
+
+
+
+   <img src="https://images.squarespace-cdn.com/content/v1/59ebf554edaed825d0d8e200/1509659214026-74JF7RU98DUFSRM4QZWF/Hippo.jpg?format=original" alt="3D printed hippopotamus model" />
+
+
+
+   <img src="https://images.squarespace-cdn.com/content/v1/59ebf554edaed825d0d8e200/1509659220097-L3YQ51ZF5RGP9EYTJSKC/Build-Max-10.jpg?format=original" alt="Building and assembling Max character" />
+
 
 </div>
 
@@ -135,41 +135,41 @@
 
 <div class="image-gallery-wrapper">
 
-  
-   <img src="https://images.squarespace-cdn.com/content/v1/59ebf554edaed825d0d8e200/1509659456443-9I17F85MFBLE88IVD5AZ/ShivaniPatel-1.jpg?format=original" />
-  
 
-  
-   <img src="https://images.squarespace-cdn.com/content/v1/59ebf554edaed825d0d8e200/1509659447716-LVKID2TU0ML6VEHV5KH6/Skull-1.jpg?format=original" />
-  
+   <img src="https://images.squarespace-cdn.com/content/v1/59ebf554edaed825d0d8e200/1509659456443-9I17F85MFBLE88IVD5AZ/ShivaniPatel-1.jpg?format=original" alt="Maker Shivani Patel with 3D printed project" />
 
-  
-   <img src="https://images.squarespace-cdn.com/content/v1/59ebf554edaed825d0d8e200/1509659465798-TEF7JTTK8OOE9PKCGGGU/Order-Online-e1487546902493.jpg?format=original" />
-  
 
-  
-   <img src="https://images.squarespace-cdn.com/content/v1/59ebf554edaed825d0d8e200/1509659476295-CNV5RMNY0G6OJY508VN0/Carabiners.jpg?format=original" />
-  
 
-  
-   <img src="https://images.squarespace-cdn.com/content/v1/59ebf554edaed825d0d8e200/1509659486363-L4VA8JP5ENAIE5VZR2II/Dragon-Box.jpg?format=original" />
-  
+   <img src="https://images.squarespace-cdn.com/content/v1/59ebf554edaed825d0d8e200/1509659447716-LVKID2TU0ML6VEHV5KH6/Skull-1.jpg?format=original" alt="3D printed anatomical skull model" />
 
-  
-   <img src="https://images.squarespace-cdn.com/content/v1/59ebf554edaed825d0d8e200/1509659495873-F40G9UIWD24DAMLBT8PR/reese.jpeg?format=original" />
-  
 
-  
-   <img src="https://images.squarespace-cdn.com/content/v1/59ebf554edaed825d0d8e200/1509659505118-3Q2HZA0NOV15M1R7KN85/will-7.jpg?format=original" />
-  
 
-  
-   <img src="https://images.squarespace-cdn.com/content/v1/59ebf554edaed825d0d8e200/1509659514935-WTNLHJ08P3O99275KSAI/Ribs-2.jpg?format=original" />
-  
+   <img src="https://images.squarespace-cdn.com/content/v1/59ebf554edaed825d0d8e200/1509659465798-TEF7JTTK8OOE9PKCGGGU/Order-Online-e1487546902493.jpg?format=original" alt="Order online 3D printing services" />
 
-  
-   <img src="https://images.squarespace-cdn.com/content/v1/59ebf554edaed825d0d8e200/1509659522362-E8HDYAO99JNFDC3ZO2YB/Birthday-Card-1.jpg?format=original" />
-  
+
+
+   <img src="https://images.squarespace-cdn.com/content/v1/59ebf554edaed825d0d8e200/1509659476295-CNV5RMNY0G6OJY508VN0/Carabiners.jpg?format=original" alt="3D printed carabiners" />
+
+
+
+   <img src="https://images.squarespace-cdn.com/content/v1/59ebf554edaed825d0d8e200/1509659486363-L4VA8JP5ENAIE5VZR2II/Dragon-Box.jpg?format=original" alt="3D printed dragon box design" />
+
+
+
+   <img src="https://images.squarespace-cdn.com/content/v1/59ebf554edaed825d0d8e200/1509659495873-F40G9UIWD24DAMLBT8PR/reese.jpeg?format=original" alt="Student Reese with 3D printed project" />
+
+
+
+   <img src="https://images.squarespace-cdn.com/content/v1/59ebf554edaed825d0d8e200/1509659505118-3Q2HZA0NOV15M1R7KN85/will-7.jpg?format=original" alt="Student Will with 3D printed project" />
+
+
+
+   <img src="https://images.squarespace-cdn.com/content/v1/59ebf554edaed825d0d8e200/1509659514935-WTNLHJ08P3O99275KSAI/Ribs-2.jpg?format=original" alt="3D printed anatomical rib cage model" />
+
+
+
+   <img src="https://images.squarespace-cdn.com/content/v1/59ebf554edaed825d0d8e200/1509659522362-E8HDYAO99JNFDC3ZO2YB/Birthday-Card-1.jpg?format=original" alt="3D printed birthday card design" />
+
 
 </div>
 

--- a/summer.html
+++ b/summer.html
@@ -71,8 +71,8 @@
 <hr />
 
 
-  
-      <a href="https://www.eventbrite.com/e/adventures-in-3d-modeling-and-design-with-tinkercad-2024-summer-camp-tickets-882363812917"  target="_blank" ><img src="https://images.squarespace-cdn.com/content/v1/59ebf554edaed825d0d8e200/9186d038-eb73-4f9b-a420-ade4dd4dc1bd/tinkercad.PNG?format=original" alt=""/></a>
+
+      <a href="https://www.eventbrite.com/e/adventures-in-3d-modeling-and-design-with-tinkercad-2024-summer-camp-tickets-882363812917"  target="_blank" ><img src="https://images.squarespace-cdn.com/content/v1/59ebf554edaed825d0d8e200/9186d038-eb73-4f9b-a420-ade4dd4dc1bd/tinkercad.PNG?format=original" alt="Adventures in 3D Modeling and Design with TinkerCad Summer Camp 2024" /></a>
   
 
 


### PR DESCRIPTION
- Added CSS grid layout for .image-gallery-wrapper class
  - Responsive grid with auto-fit columns (minmax 250px)
  - 20px gap between images matching original site spacing
  - Hover effects with transform and shadow
  - Mobile responsive breakpoints at 768px and 480px

- Added descriptive alt text to images in main pages:
  - lab-staff.html: Faculty, advisory board, and staff photos
  - partners.html: Ultimaker printer photos
  - pricingservices.html: 3D printed project examples
  - resources.html: Project gallery and maker photos
  - summer.html: Summer camp promotional images

Images now display in proper grid layout matching original makerlab.illinois.edu site