### PR TITLE
Fix CSS specificity for homepage feature cards

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -734,7 +734,7 @@ img {
   }
 }
 
-/* Feature Cards */
+/* Feature Cards - Alternative style for other pages */
 .feature-cards {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
@@ -742,21 +742,24 @@ img {
   margin: var(--spacing-lg) 0;
 }
 
-.feature-card {
+.feature-cards .feature-card {
   background: var(--white);
   border-radius: 12px;
   overflow: hidden;
   box-shadow: 0 4px 15px rgba(0,0,0,0.1);
   transition: all 0.3s ease;
   text-align: center;
+  position: relative;
+  min-height: auto;
 }
 
-.feature-card:hover {
+.feature-cards .feature-card:hover {
   transform: translateY(-8px);
   box-shadow: 0 8px 25px rgba(0,0,0,0.15);
 }
 
-.feature-card-image {
+.feature-cards .feature-card-image {
+  position: relative;
   width: 100%;
   height: 250px;
   object-fit: cover;
@@ -766,13 +769,13 @@ img {
   padding: var(--spacing-md);
 }
 
-.feature-card h2 {
+.feature-cards .feature-card h2 {
   font-size: 1.75rem;
   margin-bottom: var(--spacing-sm);
   color: var(--illinois-blue);
 }
 
-.feature-card p {
+.feature-cards .feature-card p {
   color: var(--text-light);
   margin-bottom: var(--spacing-md);
   line-height: 1.6;


### PR DESCRIPTION
Made the alternative feature card styles more specific to avoid overriding the homepage orange/blue card backgrounds. Now:
- .feature-cards .feature-card applies only to cards in .feature-cards
- .feature-card applies to homepage cards in .feature-cards-grid

Fixes the issue where LAB HOURS and ORDER HERE cards were showing white backgrounds instead of orange and blue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)