### PR TITLE
Migrate images from Squarespace to GitHub

### DIFF
--- a/birthday-parties.html
+++ b/birthday-parties.html
@@ -74,7 +74,7 @@
   
 
   
-   <img src="/images/events/Birthday_Party-3.jpg" />
+   <img src="/makerlab/images/events/Birthday_Party-3.jpg" />
   
 
   
@@ -90,7 +90,7 @@
   
 
   
-   <img src="/images/events/bday_3.jpg" />
+   <img src="/makerlab/images/events/bday_3.jpg" />
   
 
 </div>

--- a/blog/10-reasons-to-have-a-birthday-party-at-the-makerlab.html
+++ b/blog/10-reasons-to-have-a-birthday-party-at-the-makerlab.html
@@ -76,7 +76,7 @@
   
 
   
-   <img src="/images/blog/20160409_154524.jpg" />
+   <img src="/makerlab/images/blog/20160409_154524.jpg" />
   
 
   

--- a/blog/3d-model-of-uic-new-academic-and-residential-complex.html
+++ b/blog/3d-model-of-uic-new-academic-and-residential-complex.html
@@ -71,7 +71,7 @@
 
 
   
-      <img src="/images/blog/UIC_Picture.jpeg" alt=""/>
+      <img src="/makerlab/images/blog/UIC_Picture.jpeg" alt=""/>
   
 
 

--- a/blog/3d-printed-infant-torso.html
+++ b/blog/3d-printed-infant-torso.html
@@ -76,7 +76,7 @@
   
 
   
-   <img src="/images/general/Ribs-2.jpg" />
+   <img src="/makerlab/images/general/Ribs-2.jpg" />
   
 
 </div>

--- a/blog/3d-printed-pollen-grain-explains-changes-in-landscape.html
+++ b/blog/3d-printed-pollen-grain-explains-changes-in-landscape.html
@@ -42,7 +42,7 @@
               Published on Mon, 18 Sep 2017
                by GuestUser
             </div>
-            <img src="/images/blog/Dad_pollen_model.jpeg" alt=""/>
+            <img src="/makerlab/images/blog/Dad_pollen_model.jpeg" alt=""/>
   
 
 

--- a/blog/3d-printing-at-admitted-students-day.html
+++ b/blog/3d-printing-at-admitted-students-day.html
@@ -72,15 +72,15 @@
 <div class="image-gallery-wrapper">
 
   
-   <img src="/images/blog/photo.jpg" />
+   <img src="/makerlab/images/blog/photo.jpg" />
   
 
   
-   <img src="/images/blog/Faa_3dprinter.jpeg" />
+   <img src="/makerlab/images/blog/Faa_3dprinter.jpeg" />
   
 
   
-   <img src="/images/blog/Faa_3dprinter2.jpeg" />
+   <img src="/makerlab/images/blog/Faa_3dprinter2.jpeg" />
   
 
 </div>

--- a/blog/3d-printing-conference-a-big-success.html
+++ b/blog/3d-printing-conference-a-big-success.html
@@ -71,7 +71,7 @@
 
 
   
-       [caption id="" align="alignnone" width="2500"]<a href="http://images.squarespace-cdn.com/content/v1/59ebf554edaed825d0d8e200/1509139421944-4NP0OMDOUY317UL72DWO/Dean-Conference.jpg" ><img src="/images/blog/Dean-Conference.jpg" alt="Dean Conference"/></a> Dean Conference[/caption] 
+       [caption id="" align="alignnone" width="2500"]<a href="http://images.squarespace-cdn.com/content/v1/59ebf554edaed825d0d8e200/1509139421944-4NP0OMDOUY317UL72DWO/Dean-Conference.jpg" ><img src="/makerlab/images/blog/Dean-Conference.jpg" alt="Dean Conference"/></a> Dean Conference[/caption] 
   
 
 

--- a/blog/3d-printing-in-sports-digital-making-2017.html
+++ b/blog/3d-printing-in-sports-digital-making-2017.html
@@ -78,7 +78,7 @@
   
 
   
-   <img src="/images/blog/Adidas.jpg" />
+   <img src="/makerlab/images/blog/Adidas.jpg" />
   
 
   

--- a/blog/3d-prints-in-the-alma-mater-time-capsule.html
+++ b/blog/3d-prints-in-the-alma-mater-time-capsule.html
@@ -42,7 +42,7 @@
               Published on Thu, 24 Apr 2014
                by KatieKhau
             </div>
-            [caption id="" align="alignnone" width="250"]<a href="http://images.squarespace-cdn.com/content/v1/59ebf554edaed825d0d8e200/1509139367245-976MGLSA5107UDKHJFF3/Time-Capsule.jpg" ><img src="/images/blog/Time-Capsule.jpg" alt="Time Capsule"/></a> Time Capsule[/caption] 
+            [caption id="" align="alignnone" width="250"]<a href="http://images.squarespace-cdn.com/content/v1/59ebf554edaed825d0d8e200/1509139367245-976MGLSA5107UDKHJFF3/Time-Capsule.jpg" ><img src="/makerlab/images/blog/Time-Capsule.jpg" alt="Time Capsule"/></a> Time Capsule[/caption] 
   
 
 

--- a/blog/4839.html
+++ b/blog/4839.html
@@ -42,7 +42,7 @@
               Published on Mon, 31 Oct 2016
                by GuestUser
             </div>
-            <img src="/images/blog/Prototype-Hardware-Demonstrator.jpg" alt=""/>
+            <img src="/makerlab/images/blog/Prototype-Hardware-Demonstrator.jpg" alt=""/>
   
 
 
@@ -76,7 +76,7 @@
 
 
   
-       [caption id="" align="alignnone" width="1637"]<img src="/images/blog/Prototype-Hardware-Demonstrator.jpg" alt=" prototype-hardware-demonstrator "/>  prototype-hardware-demonstrator [/caption]
+       [caption id="" align="alignnone" width="1637"]<img src="/makerlab/images/blog/Prototype-Hardware-Demonstrator.jpg" alt=" prototype-hardware-demonstrator "/>  prototype-hardware-demonstrator [/caption]
             <div class="mt-3">
               <a href="/makerlab/blog/index.html" class="btn btn-secondary">← Back to Blog</a>
             </div>

--- a/blog/5923.html
+++ b/blog/5923.html
@@ -76,7 +76,7 @@
   
 
   
-   <img src="/images/blog/Car-Print-2.jpg" />
+   <img src="/makerlab/images/blog/Car-Print-2.jpg" />
   
 
   

--- a/blog/a-3d-printed-skyrim-digital-book.html
+++ b/blog/a-3d-printed-skyrim-digital-book.html
@@ -72,11 +72,11 @@
 <div class="image-gallery-wrapper">
 
   
-   <img src="/images/blog/Skyrim-Book-1-4.jpg" />
+   <img src="/makerlab/images/blog/Skyrim-Book-1-4.jpg" />
   
 
   
-   <img src="/images/blog/Skyrim-Book-2-1.jpg" />
+   <img src="/makerlab/images/blog/Skyrim-Book-2-1.jpg" />
   
 
   
@@ -84,7 +84,7 @@
   
 
   
-   <img src="/images/blog/Skyrim-Book-4-1.jpg" />
+   <img src="/makerlab/images/blog/Skyrim-Book-4-1.jpg" />
   
 
 </div>

--- a/blog/beauty-in-equations.html
+++ b/blog/beauty-in-equations.html
@@ -42,7 +42,7 @@
               Published on Wed, 24 Feb 2016
                by IllinoisMakerLab
             </div>
-            <img src="/images/blog/math_designs.jpg" alt=""/>
+            <img src="/makerlab/images/blog/math_designs.jpg" alt=""/>
   
 
 

--- a/blog/bring-3d-printing-to-the-world-in-the-new-year.html
+++ b/blog/bring-3d-printing-to-the-world-in-the-new-year.html
@@ -42,7 +42,7 @@
               Published on Mon, 11 Jan 2016
                by IllinoisMakerLab
             </div>
-            <img src="/images/blog/IMG_20160125_152253237.jpg" alt=""/>
+            <img src="/makerlab/images/blog/IMG_20160125_152253237.jpg" alt=""/>
   
 
 

--- a/blog/catch-pokeprint-on-campus-and-print-more-at-the-lab.html
+++ b/blog/catch-pokeprint-on-campus-and-print-more-at-the-lab.html
@@ -76,11 +76,11 @@
   
 
   
-   <img src="/images/blog/Image-July-19-2016-3_26_16-PM.jpg" />
+   <img src="/makerlab/images/blog/Image-July-19-2016-3_26_16-PM.jpg" />
   
 
   
-   <img src="/images/blog/Image-July-20-2016-12_53_37-PM.jpg" />
+   <img src="/makerlab/images/blog/Image-July-20-2016-12_53_37-PM.jpg" />
   
 
 </div>

--- a/blog/caterpillar-supports-the-makerlab-with-a-7500-course-and-program-grant.html
+++ b/blog/caterpillar-supports-the-makerlab-with-a-7500-course-and-program-grant.html
@@ -42,7 +42,7 @@
               Published on Fri, 31 Jul 2015
                by IllinoisMakerLab
             </div>
-            <img src="/images/blog/index.png" alt=""/>
+            <img src="/makerlab/images/blog/index.png" alt=""/>
   
 
 

--- a/blog/celebrate-your-next-birthday-with-us.html
+++ b/blog/celebrate-your-next-birthday-with-us.html
@@ -42,7 +42,7 @@
               Published on Mon, 11 Apr 2016
                by IllinoisMakerLab
             </div>
-            <img src="/images/blog/IMG_20160515_153253590.jpg" alt=""/>
+            <img src="/makerlab/images/blog/IMG_20160515_153253590.jpg" alt=""/>
   
 
 
@@ -91,7 +91,7 @@ Our premium <em>birthday party packages include</em>:</p><ul id="yui_3_17_2_8_15
 
 
   
-       [caption id="" align="alignnone" width="2500"]<img src="/images/blog/20160409_154524.jpg" alt="20160409_154524"/> 20160409_154524[/caption] 
+       [caption id="" align="alignnone" width="2500"]<img src="/makerlab/images/blog/20160409_154524.jpg" alt="20160409_154524"/> 20160409_154524[/caption] 
   
 
 

--- a/blog/champaign-public-library-outreach.html
+++ b/blog/champaign-public-library-outreach.html
@@ -72,15 +72,15 @@
 <div class="image-gallery-wrapper">
 
   
-   <img src="/images/blog/Image_October_31__2018_11_54_35_AM.jpg" />
+   <img src="/makerlab/images/blog/Image_October_31__2018_11_54_35_AM.jpg" />
   
 
   
-   <img src="/images/blog/Image_October_31__2018_11_54_44_AM.jpg" />
+   <img src="/makerlab/images/blog/Image_October_31__2018_11_54_44_AM.jpg" />
   
 
   
-   <img src="/images/blog/Image_October_31__2018_11_58_01_AM.jpg" />
+   <img src="/makerlab/images/blog/Image_October_31__2018_11_58_01_AM.jpg" />
   
 
 </div>

--- a/blog/design-auditing-digital-making-2017.html
+++ b/blog/design-auditing-digital-making-2017.html
@@ -72,7 +72,7 @@
 <div class="image-gallery-wrapper">
 
   
-   <img src="/images/blog/Design-Audit.jpg" />
+   <img src="/makerlab/images/blog/Design-Audit.jpg" />
   
 
   
@@ -80,11 +80,11 @@
   
 
   
-   <img src="/images/blog/Design-Audit-3.jpg" />
+   <img src="/makerlab/images/blog/Design-Audit-3.jpg" />
   
 
   
-   <img src="/images/blog/Design-Audit-2.jpg" />
+   <img src="/makerlab/images/blog/Design-Audit-2.jpg" />
   
 
   

--- a/blog/designed-and-printed-at-the-lab-light-fixtures.html
+++ b/blog/designed-and-printed-at-the-lab-light-fixtures.html
@@ -80,7 +80,7 @@
   
 
   
-   <img src="/images/blog/Light-Fixture-2-1.jpg" />
+   <img src="/makerlab/images/blog/Light-Fixture-2-1.jpg" />
   
 
 </div>

--- a/blog/designed-and-printed-at-the-lab-train-placard.html
+++ b/blog/designed-and-printed-at-the-lab-train-placard.html
@@ -76,7 +76,7 @@
   
 
   
-   <img src="/images/blog/Train-Placard-1-1.png" />
+   <img src="/makerlab/images/blog/Train-Placard-1-1.png" />
   
 
 </div>

--- a/blog/digital-making-week-2-reflection.html
+++ b/blog/digital-making-week-2-reflection.html
@@ -234,7 +234,7 @@
 
 
   
-      <img src="/images/blog/week2-4.png" alt=""/>
+      <img src="/makerlab/images/blog/week2-4.png" alt=""/>
   
 
 
@@ -268,7 +268,7 @@
 
 
   
-      <img src="/images/blog/week2-5.png" alt=""/>
+      <img src="/makerlab/images/blog/week2-5.png" alt=""/>
   
 
 

--- a/blog/digital-making-what-have-we-been-up-to.html
+++ b/blog/digital-making-what-have-we-been-up-to.html
@@ -42,7 +42,7 @@
               Published on Thu, 23 Apr 2015
                by IllinoisMakerLab
             </div>
-            <img src="/images/blog/Screen-Shot-2015-02-17-at-4.52.55-PM-e1425075328182-121x150.png" alt=""/>
+            <img src="/makerlab/images/blog/Screen-Shot-2015-02-17-at-4.52.55-PM-e1425075328182-121x150.png" alt=""/>
   
 
 

--- a/blog/employee-spotlight-rachael-kuehr.html
+++ b/blog/employee-spotlight-rachael-kuehr.html
@@ -71,7 +71,7 @@
 
 
   
-       [caption id="" align="alignnone" width="2500"]<img src="/images/blog/IMG_6018.jpg" alt=" Pictured is Rachel holding the 20 foot-long-chain! "/>  Pictured is Rachel holding the 20 foot-long-chain! [/caption]
+       [caption id="" align="alignnone" width="2500"]<img src="/makerlab/images/blog/IMG_6018.jpg" alt=" Pictured is Rachel holding the 20 foot-long-chain! "/>  Pictured is Rachel holding the 20 foot-long-chain! [/caption]
             <div class="mt-3">
               <a href="/makerlab/blog/index.html" class="btn btn-secondary">← Back to Blog</a>
             </div>

--- a/blog/empowering-innovations.html
+++ b/blog/empowering-innovations.html
@@ -71,7 +71,7 @@
 
 
   
-      <img src="/images/blog/IMG_20200414_122203.jpg" alt=""/>
+      <img src="/makerlab/images/blog/IMG_20200414_122203.jpg" alt=""/>
   
 
 <hr />

--- a/blog/enabling-the-future-one-3dprinted-hand-at-a-time.html
+++ b/blog/enabling-the-future-one-3dprinted-hand-at-a-time.html
@@ -42,7 +42,7 @@
               Published on Fri, 12 Jun 2015
                by IllinoisMakerLab
             </div>
-            <img src="/images/blog/enable.jpg" alt=""/>
+            <img src="/makerlab/images/blog/enable.jpg" alt=""/>
   
 
 

--- a/blog/exploring-the-fab-lab-digital-making-2017.html
+++ b/blog/exploring-the-fab-lab-digital-making-2017.html
@@ -75,11 +75,11 @@
 <div class="image-gallery-wrapper">
 
   
-   <img src="/images/blog/Laser-Cutting.jpg" />
+   <img src="/makerlab/images/blog/Laser-Cutting.jpg" />
   
 
   
-   <img src="/images/blog/Fab-Lab-box.jpg" />
+   <img src="/makerlab/images/blog/Fab-Lab-box.jpg" />
   
 
 </div>
@@ -155,11 +155,11 @@
 <div class="image-gallery-wrapper">
 
   
-   <img src="/images/blog/Exploring-the-Fab-Lab-3.jpg" />
+   <img src="/makerlab/images/blog/Exploring-the-Fab-Lab-3.jpg" />
   
 
   
-   <img src="/images/blog/Arduino-Software-App.png" />
+   <img src="/makerlab/images/blog/Arduino-Software-App.png" />
   
 
 </div>

--- a/blog/final-reflections-digital-making-2017.html
+++ b/blog/final-reflections-digital-making-2017.html
@@ -76,7 +76,7 @@
 <div class="image-gallery-wrapper">
 
   
-   <img src="/images/blog/Team-MakerLax-2.jpg" />
+   <img src="/makerlab/images/blog/Team-MakerLax-2.jpg" />
   
 
   
@@ -84,7 +84,7 @@
   
 
   
-   <img src="/images/blog/Team-MakerLax-1.png" />
+   <img src="/makerlab/images/blog/Team-MakerLax-1.png" />
   
 
 </div>
@@ -123,11 +123,11 @@
 <div class="image-gallery-wrapper">
 
   
-   <img src="/images/blog/Arduino-Software-App.png" />
+   <img src="/makerlab/images/blog/Arduino-Software-App.png" />
   
 
   
-   <img src="/images/blog/Design-Audit.jpg" />
+   <img src="/makerlab/images/blog/Design-Audit.jpg" />
   
 
 </div>
@@ -166,15 +166,15 @@
 <div class="image-gallery-wrapper">
 
   
-   <img src="/images/blog/Endless.jpg" />
+   <img src="/makerlab/images/blog/Endless.jpg" />
   
 
   
-   <img src="/images/blog/Endless-1.jpg" />
+   <img src="/makerlab/images/blog/Endless-1.jpg" />
   
 
   
-   <img src="/images/blog/Endless-2.jpg" />
+   <img src="/makerlab/images/blog/Endless-2.jpg" />
   
 
 </div>

--- a/blog/fostering-entrepreneurship-and-interdisciplinary-team-work.html
+++ b/blog/fostering-entrepreneurship-and-interdisciplinary-team-work.html
@@ -42,7 +42,7 @@
               Published on Mon, 26 Oct 2015
                by AricRindfleisch
             </div>
-            [caption id="" align="alignnone" width="864"]<a href="http://images.squarespace-cdn.com/content/v1/59ebf554edaed825d0d8e200/1509139420632-RLBDC6R9DX1NDGTVQ1IY/76384.jpg" ><img src="/images/blog/76384.jpg" alt="Nora Benson - undergraduate student who used the MakerLab."/></a> Nora Benson - undergraduate student who used the MakerLab.[/caption] 
+            [caption id="" align="alignnone" width="864"]<a href="http://images.squarespace-cdn.com/content/v1/59ebf554edaed825d0d8e200/1509139420632-RLBDC6R9DX1NDGTVQ1IY/76384.jpg" ><img src="/makerlab/images/blog/76384.jpg" alt="Nora Benson - undergraduate student who used the MakerLab."/></a> Nora Benson - undergraduate student who used the MakerLab.[/caption] 
   
 
 

--- a/blog/free-print-wednesdays-sponsored-by-ultimaker.html
+++ b/blog/free-print-wednesdays-sponsored-by-ultimaker.html
@@ -42,14 +42,14 @@
               Published on Wed, 27 Jan 2016
                by IllinoisMakerLab
             </div>
-            <img src="/images/general/Ultimakers-Lab.jpg" alt=""/>
+            <img src="/makerlab/images/general/Ultimakers-Lab.jpg" alt=""/>
   
 
 
 
 
   
-       [caption id="" align="alignnone" width="279"]<a href="http://images.squarespace-cdn.com/content/v1/59ebf554edaed825d0d8e200/1509146539941-FRUSZN9JAVRJKV6X42VH/free-stuff_jpg.gif" ><img src="/images/general/free-stuff_jpg.gif" alt="free-stuff_jpg"/></a> free-stuff_jpg[/caption] 
+       [caption id="" align="alignnone" width="279"]<a href="http://images.squarespace-cdn.com/content/v1/59ebf554edaed825d0d8e200/1509146539941-FRUSZN9JAVRJKV6X42VH/free-stuff_jpg.gif" ><img src="/makerlab/images/general/free-stuff_jpg.gif" alt="free-stuff_jpg"/></a> free-stuff_jpg[/caption] 
   
 
 
@@ -83,7 +83,7 @@
 
 
   
-       [caption id="" align="alignnone" width="600"]<img src="/images/general/Ultimakers-Lab.jpg" alt="All new Ultimaker 2 printers in the Makerlab"/> All new Ultimaker 2 printers in the Makerlab[/caption]
+       [caption id="" align="alignnone" width="600"]<img src="/makerlab/images/general/Ultimakers-Lab.jpg" alt="All new Ultimaker 2 printers in the Makerlab"/> All new Ultimaker 2 printers in the Makerlab[/caption]
             <div class="mt-3">
               <a href="/makerlab/blog/index.html" class="btn btn-secondary">← Back to Blog</a>
             </div>

--- a/blog/fusion-360-two-weeks-coming-full-circle.html
+++ b/blog/fusion-360-two-weeks-coming-full-circle.html
@@ -72,7 +72,7 @@
 <div class="image-gallery-wrapper">
 
   
-   <img src="/images/blog/Lr_5299-150x95.jpg" />
+   <img src="/makerlab/images/blog/Lr_5299-150x95.jpg" />
   
 
   
@@ -92,15 +92,15 @@
   
 
   
-   <img src="/images/blog/Snip20150301_1-140x150.png" />
+   <img src="/makerlab/images/blog/Snip20150301_1-140x150.png" />
   
 
   
-   <img src="/images/blog/Screen-Shot-2015-02-17-at-4.52.55-PM-e1425075328182-121x150.png" />
+   <img src="/makerlab/images/blog/Screen-Shot-2015-02-17-at-4.52.55-PM-e1425075328182-121x150.png" />
   
 
   
-   <img src="/images/blog/Screen-Shot-2015-03-01-at-5.57.41-PM-300x190.png" />
+   <img src="/makerlab/images/blog/Screen-Shot-2015-03-01-at-5.57.41-PM-300x190.png" />
   
 
 </div>

--- a/blog/giant-pollen-grains-helping-kids-understand-climate-change.html
+++ b/blog/giant-pollen-grains-helping-kids-understand-climate-change.html
@@ -42,7 +42,7 @@
               Published on Mon, 29 Jun 2015
                by IllinoisMakerLab
             </div>
-            [caption id="" align="alignnone" width="965"]<a href="http://images.squarespace-cdn.com/content/v1/59ebf554edaed825d0d8e200/1509139408054-RD299AQD3N3PKPIYBZD4/pollen.png" ><img src="/images/blog/pollen.png" alt="Pollen grains printed by the MakerLab. Orange represents a water-willow pollen. Yellow was taken from a white spruce. Photo by Kathryn Coulter"/></a> Pollen grains printed by the MakerLab. Orange represents a water-willow pollen. Yellow was taken from a white spruce. Photo by Kathryn Coulter[/caption] 
+            [caption id="" align="alignnone" width="965"]<a href="http://images.squarespace-cdn.com/content/v1/59ebf554edaed825d0d8e200/1509139408054-RD299AQD3N3PKPIYBZD4/pollen.png" ><img src="/makerlab/images/blog/pollen.png" alt="Pollen grains printed by the MakerLab. Orange represents a water-willow pollen. Yellow was taken from a white spruce. Photo by Kathryn Coulter"/></a> Pollen grains printed by the MakerLab. Orange represents a water-willow pollen. Yellow was taken from a white spruce. Photo by Kathryn Coulter[/caption] 
   
 
 

--- a/blog/guru-interview-linxi-liu.html
+++ b/blog/guru-interview-linxi-liu.html
@@ -71,7 +71,7 @@
 
 
   
-      <img src="/images/blog/Linxi-Liu.jpg" alt=""/>
+      <img src="/makerlab/images/blog/Linxi-Liu.jpg" alt=""/>
   
 
 

--- a/blog/guru-spotlight-almasa-krvavac.html
+++ b/blog/guru-spotlight-almasa-krvavac.html
@@ -139,7 +139,7 @@
   
 
   
-   <img src="/images/blog/IMG_0029__1_.jpg" />
+   <img src="/makerlab/images/blog/IMG_0029__1_.jpg" />
   
 
 </div>

--- a/blog/hearts-for-carle-college-of-medicine.html
+++ b/blog/hearts-for-carle-college-of-medicine.html
@@ -80,7 +80,7 @@
   
 
   
-   <img src="/images/blog/3D-cast.png" />
+   <img src="/makerlab/images/blog/3D-cast.png" />
   
 
   

--- a/blog/high-school-seniors-learn-3d-printing.html
+++ b/blog/high-school-seniors-learn-3d-printing.html
@@ -72,7 +72,7 @@
 <div class="image-gallery-wrapper">
 
   
-   <img src="/images/blog/IMG_0511.jpg" />
+   <img src="/makerlab/images/blog/IMG_0511.jpg" />
   
 
   

--- a/blog/ideas-to-products-in-24-hours-imaginationu-summer-camp.html
+++ b/blog/ideas-to-products-in-24-hours-imaginationu-summer-camp.html
@@ -76,7 +76,7 @@
   
 
   
-   <img src="/images/blog/photo-2.jpg" />
+   <img src="/makerlab/images/blog/photo-2.jpg" />
   
 
 </div>
@@ -115,7 +115,7 @@ https://youtu.be/ToFToSFDryA</p>
 <div class="image-gallery-wrapper">
 
   
-   <img src="/images/blog/photo-2.png" />
+   <img src="/makerlab/images/blog/photo-2.png" />
   
 
   
@@ -123,7 +123,7 @@ https://youtu.be/ToFToSFDryA</p>
   
 
   
-   <img src="/images/blog/176313897.jpg" />
+   <img src="/makerlab/images/blog/176313897.jpg" />
   
 
 </div>

--- a/blog/illinois-makerlab-at-illinois-womens-basketball-field-trip-day.html
+++ b/blog/illinois-makerlab-at-illinois-womens-basketball-field-trip-day.html
@@ -72,11 +72,11 @@
 <div class="image-gallery-wrapper">
 
   
-   <img src="/images/blog/Image_November_7__2018_2_54_54_PM.jpg" />
+   <img src="/makerlab/images/blog/Image_November_7__2018_2_54_54_PM.jpg" />
   
 
   
-   <img src="/images/blog/IMG_1182__1_.jpg" />
+   <img src="/makerlab/images/blog/IMG_1182__1_.jpg" />
   
 
   
@@ -84,7 +84,7 @@
   
 
   
-   <img src="/images/blog/Image_November_7__2018_2_55_21_PM.jpg" />
+   <img src="/makerlab/images/blog/Image_November_7__2018_2_55_21_PM.jpg" />
   
 
   
@@ -96,11 +96,11 @@
   
 
   
-   <img src="/images/blog/Image_November_7__2018_2_58_12_PM.jpg" />
+   <img src="/makerlab/images/blog/Image_November_7__2018_2_58_12_PM.jpg" />
   
 
   
-   <img src="/images/blog/Image_November_7__2018_2_57_20_PM.jpg" />
+   <img src="/makerlab/images/blog/Image_November_7__2018_2_57_20_PM.jpg" />
   
 
 </div>

--- a/blog/illinois-makerlab-collaborated-with-thera-solutions-functionalhand.html
+++ b/blog/illinois-makerlab-collaborated-with-thera-solutions-functionalhand.html
@@ -76,7 +76,7 @@
   
 
   
-   <img src="/images/blog/Henry_with_Functional_Hand-20.jpg" />
+   <img src="/makerlab/images/blog/Henry_with_Functional_Hand-20.jpg" />
   
 
 </div>

--- a/blog/illinois-makerlab-collaboration-with-makers-for-covid-19.html
+++ b/blog/illinois-makerlab-collaboration-with-makers-for-covid-19.html
@@ -49,7 +49,7 @@
   
 
   
-   <img src="/images/general/IMG_8347.jpg" />
+   <img src="/makerlab/images/general/IMG_8347.jpg" />
   
 
 </div>

--- a/blog/illinois-makerlab-completes-3d-printed-hand.html
+++ b/blog/illinois-makerlab-completes-3d-printed-hand.html
@@ -76,7 +76,7 @@
   
 
   
-   <img src="/images/blog/IMG_7017.jpg" />
+   <img src="/makerlab/images/blog/IMG_7017.jpg" />
   
 
 </div>

--- a/blog/illinois-makerlab-launches-1-to-1-virtual-tutoring.html
+++ b/blog/illinois-makerlab-launches-1-to-1-virtual-tutoring.html
@@ -76,7 +76,7 @@
 
 
   
-      <img src="/images/general/wheel.PNG" alt=""/>
+      <img src="/makerlab/images/general/wheel.PNG" alt=""/>
   
 
 

--- a/blog/illinois-makerlab-participates-at-national-manufacturing-day.html
+++ b/blog/illinois-makerlab-participates-at-national-manufacturing-day.html
@@ -76,7 +76,7 @@
   
 
   
-   <img src="/images/blog/Image_October_7__2018_10_29_04_PM.jpg" />
+   <img src="/makerlab/images/blog/Image_October_7__2018_10_29_04_PM.jpg" />
   
 
   
@@ -84,11 +84,11 @@
   
 
   
-   <img src="/images/blog/43253006_10156066795832807_1736328876885278720_n.jpg" />
+   <img src="/makerlab/images/blog/43253006_10156066795832807_1736328876885278720_n.jpg" />
   
 
   
-   <img src="/images/blog/43206924_10156066795812807_4893717468280782848_n.jpg" />
+   <img src="/makerlab/images/blog/43206924_10156066795812807_4893717468280782848_n.jpg" />
   
 
   

--- a/blog/illinois-makerlab-spearheads-covid-19-campus-response-efforts.html
+++ b/blog/illinois-makerlab-spearheads-covid-19-campus-response-efforts.html
@@ -105,14 +105,14 @@
 
 
   
-      <img src="/images/blog/Screenshot_20200401-103435.png" alt=""/>
+      <img src="/makerlab/images/blog/Screenshot_20200401-103435.png" alt=""/>
   
 
 
 
 
   
-      <img src="/images/summer/图像_2020年4月13日_下午9_35_50.jpg" alt=""/>
+      <img src="/makerlab/images/summer/图像_2020年4月13日_下午9_35_50.jpg" alt=""/>
   
 
 
@@ -146,7 +146,7 @@
 
 
   
-      <img src="/images/blog/IMG_2601.jpg" alt=""/>
+      <img src="/makerlab/images/blog/IMG_2601.jpg" alt=""/>
   
 
 

--- a/blog/illinois-makerlab-supports-relay-for-life.html
+++ b/blog/illinois-makerlab-supports-relay-for-life.html
@@ -83,7 +83,7 @@
 
 
   
-       [caption id="" align="alignnone" width="2500"]<img src="/images/blog/IMG_20160312_192345.jpg" alt="IMG_20160312_192345"/> IMG_20160312_192345[/caption]
+       [caption id="" align="alignnone" width="2500"]<img src="/makerlab/images/blog/IMG_20160312_192345.jpg" alt="IMG_20160312_192345"/> IMG_20160312_192345[/caption]
             <div class="mt-3">
               <a href="/makerlab/blog/index.html" class="btn btn-secondary">← Back to Blog</a>
             </div>

--- a/blog/illinois-makerlab-team-competes-in-national-make48-competition.html
+++ b/blog/illinois-makerlab-team-competes-in-national-make48-competition.html
@@ -105,15 +105,15 @@
   
 
   
-   <img src="/images/blog/Make48_-1.jpg" />
+   <img src="/makerlab/images/blog/Make48_-1.jpg" />
   
 
   
-   <img src="/images/blog/Make48_-3.jpg" />
+   <img src="/makerlab/images/blog/Make48_-3.jpg" />
   
 
   
-   <img src="/images/blog/Make48_-_2.jpg" />
+   <img src="/makerlab/images/blog/Make48_-_2.jpg" />
   
 
 </div>

--- a/blog/illinois-makerlabs-story-with-nameplates.html
+++ b/blog/illinois-makerlabs-story-with-nameplates.html
@@ -116,7 +116,7 @@
   
 
   
-   <img src="/images/blog/图像_2020年5月11日_下午1_44_57.jpg" />
+   <img src="/makerlab/images/blog/图像_2020年5月11日_下午1_44_57.jpg" />
   
 
 </div>

--- a/blog/join-us-for-a-summer-of-making-at-the-lab.html
+++ b/blog/join-us-for-a-summer-of-making-at-the-lab.html
@@ -42,7 +42,7 @@
               Published on Fri, 29 May 2015
                by IllinoisMakerLab
             </div>
-            [caption id="" align="alignnone" width="564"]<a href="http://images.squarespace-cdn.com/content/v1/59ebf554edaed825d0d8e200/1509139368243-ZMUIBUOV0W9SBCXUXIVC/projects-car.jpg" ><img src="/images/blog/projects-car.jpg" alt="projects-car"/></a> projects-car[/caption] 
+            [caption id="" align="alignnone" width="564"]<a href="http://images.squarespace-cdn.com/content/v1/59ebf554edaed825d0d8e200/1509139368243-ZMUIBUOV0W9SBCXUXIVC/projects-car.jpg" ><img src="/makerlab/images/blog/projects-car.jpg" alt="projects-car"/></a> projects-car[/caption] 
   
 
 

--- a/blog/korean-scholar-visits-making-things-class.html
+++ b/blog/korean-scholar-visits-making-things-class.html
@@ -42,7 +42,7 @@
               Published on Mon, 20 Apr 2015
                by AricRindfleisch
             </div>
-            [caption id="" align="alignnone" width="2500"]<a href="http://images.squarespace-cdn.com/content/v1/59ebf554edaed825d0d8e200/1509139403731-LCSC28JXA4W4VWD0W3RU/Subin.jpg" ><img src="/images/blog/Subin.jpg" alt="Subin"/></a> Subin[/caption] 
+            [caption id="" align="alignnone" width="2500"]<a href="http://images.squarespace-cdn.com/content/v1/59ebf554edaed825d0d8e200/1509139403731-LCSC28JXA4W4VWD0W3RU/Subin.jpg" ><img src="/makerlab/images/blog/Subin.jpg" alt="Subin"/></a> Subin[/caption] 
   
 
 

--- a/blog/looking-at-the-future-of-3d-printing.html
+++ b/blog/looking-at-the-future-of-3d-printing.html
@@ -72,11 +72,11 @@
 <div class="image-gallery-wrapper">
 
   
-   <img src="/images/general/Minecraft-3D-Printing.jpg" />
+   <img src="/makerlab/images/general/Minecraft-3D-Printing.jpg" />
   
 
   
-   <img src="/images/blog/Drones-3D-printing.png" />
+   <img src="/makerlab/images/blog/Drones-3D-printing.png" />
   
 
   
@@ -88,7 +88,7 @@
   
 
   
-   <img src="/images/blog/Adventure-into-3D-Modeling.png" />
+   <img src="/makerlab/images/blog/Adventure-into-3D-Modeling.png" />
   
 
 </div>

--- a/blog/makergirls-project-a-resounding-success.html
+++ b/blog/makergirls-project-a-resounding-success.html
@@ -81,11 +81,11 @@ MakerGirl aims to use the MakerLab’s innovative space to open their minds to t
   
 
   
-   <img src="/images/blog/IMAG1617.jpg" />
+   <img src="/makerlab/images/blog/IMAG1617.jpg" />
   
 
   
-   <img src="/images/blog/IMG_5163.jpg" />
+   <img src="/makerlab/images/blog/IMG_5163.jpg" />
   
 
   

--- a/blog/makerlab-hosts-countryside-students.html
+++ b/blog/makerlab-hosts-countryside-students.html
@@ -45,15 +45,15 @@
             <div class="image-gallery-wrapper">
 
   
-   <img src="/images/blog/MakerLab_020.jpg" />
+   <img src="/makerlab/images/blog/MakerLab_020.jpg" />
   
 
   
-   <img src="/images/blog/MakerLab_031.jpg" />
+   <img src="/makerlab/images/blog/MakerLab_031.jpg" />
   
 
   
-   <img src="/images/blog/MakerLab_041.jpg" />
+   <img src="/makerlab/images/blog/MakerLab_041.jpg" />
   
 
   
@@ -65,15 +65,15 @@
   
 
   
-   <img src="/images/blog/MakerLab_055.jpg" />
+   <img src="/makerlab/images/blog/MakerLab_055.jpg" />
   
 
   
-   <img src="/images/blog/MakerLab_061.jpg" />
+   <img src="/makerlab/images/blog/MakerLab_061.jpg" />
   
 
   
-   <img src="/images/blog/MakerLab_064.jpg" />
+   <img src="/makerlab/images/blog/MakerLab_064.jpg" />
   
 
   

--- a/blog/makerlab-hosts-msba-students.html
+++ b/blog/makerlab-hosts-msba-students.html
@@ -76,7 +76,7 @@
   
 
   
-   <img src="/images/blog/MSBA-2.jpg" />
+   <img src="/makerlab/images/blog/MSBA-2.jpg" />
   
 
   

--- a/blog/makerlab-hosts-several-cu-area-schools.html
+++ b/blog/makerlab-hosts-several-cu-area-schools.html
@@ -125,7 +125,7 @@
   
 
   
-   <img src="/images/blog/VishalAgoraDays.jpg" />
+   <img src="/makerlab/images/blog/VishalAgoraDays.jpg" />
   
 
 </div>

--- a/blog/makerlab-hosts-workshop-for-mba-students.html
+++ b/blog/makerlab-hosts-workshop-for-mba-students.html
@@ -71,7 +71,7 @@
 
 
   
-      <img src="/images/blog/file-18.jpeg" alt=""/>
+      <img src="/makerlab/images/blog/file-18.jpeg" alt=""/>
   
 
 

--- a/blog/makerlab-visits-innovation-factory-3dpx-and-1871-in-chicago.html
+++ b/blog/makerlab-visits-innovation-factory-3dpx-and-1871-in-chicago.html
@@ -73,7 +73,7 @@ We are eager to connect with Chicago-based makers and facilitate their innovatio
 <div class="image-gallery-wrapper">
 
   
-   <img src="/images/blog/IMG_20130523_195703.jpg" />
+   <img src="/makerlab/images/blog/IMG_20130523_195703.jpg" />
   
 
   
@@ -81,15 +81,15 @@ We are eager to connect with Chicago-based makers and facilitate their innovatio
   
 
   
-   <img src="/images/blog/IMG_20130523_175222.jpg" />
+   <img src="/makerlab/images/blog/IMG_20130523_175222.jpg" />
   
 
   
-   <img src="/images/blog/IMG_20130523_165155.jpg" />
+   <img src="/makerlab/images/blog/IMG_20130523_165155.jpg" />
   
 
   
-   <img src="/images/blog/IMG_20130523_165145.jpg" />
+   <img src="/makerlab/images/blog/IMG_20130523_165145.jpg" />
   
 
   
@@ -101,11 +101,11 @@ We are eager to connect with Chicago-based makers and facilitate their innovatio
   
 
   
-   <img src="/images/blog/IMG_20130523_154908.jpg" />
+   <img src="/makerlab/images/blog/IMG_20130523_154908.jpg" />
   
 
   
-   <img src="/images/blog/Photo-May-23-4-22-55-PM.jpg" />
+   <img src="/makerlab/images/blog/Photo-May-23-4-22-55-PM.jpg" />
   
 
   

--- a/blog/makerlab-weddings-happiness.html
+++ b/blog/makerlab-weddings-happiness.html
@@ -72,7 +72,7 @@
 <div class="image-gallery-wrapper">
 
   
-   <img src="/images/blog/Wedding-Cake-Topper.jpg" />
+   <img src="/makerlab/images/blog/Wedding-Cake-Topper.jpg" />
   
 
 </div>

--- a/blog/makerlab-workshop-series-bought-to-you-by-autodesk-fusion-360.html
+++ b/blog/makerlab-workshop-series-bought-to-you-by-autodesk-fusion-360.html
@@ -71,7 +71,7 @@
 
 
   
-       [caption id="" align="alignnone" width="2500"]<a href="http://images.squarespace-cdn.com/content/v1/59ebf554edaed825d0d8e200/1509139394668-OVOJTP4285ONN6LLGKVS/IMG_4428-2.jpg" ><img src="/images/blog/IMG_4428-2.jpg" alt="Workshop series"/></a> Workshop series[/caption] 
+       [caption id="" align="alignnone" width="2500"]<a href="http://images.squarespace-cdn.com/content/v1/59ebf554edaed825d0d8e200/1509139394668-OVOJTP4285ONN6LLGKVS/IMG_4428-2.jpg" ><img src="/makerlab/images/blog/IMG_4428-2.jpg" alt="Workshop series"/></a> Workshop series[/caption] 
   
 
 

--- a/blog/makerlabbers-make-rgb-trippy-wave-lights.html
+++ b/blog/makerlabbers-make-rgb-trippy-wave-lights.html
@@ -76,15 +76,15 @@
   
 
   
-   <img src="/images/blog/photo-92.jpg" />
+   <img src="/makerlab/images/blog/photo-92.jpg" />
   
 
   
-   <img src="/images/blog/photo-89.jpg" />
+   <img src="/makerlab/images/blog/photo-89.jpg" />
   
 
   
-   <img src="/images/blog/100_7470.jpg" />
+   <img src="/makerlab/images/blog/100_7470.jpg" />
   
 
   

--- a/blog/making-things-class-develops-prototypes.html
+++ b/blog/making-things-class-develops-prototypes.html
@@ -42,7 +42,7 @@
               Published on Wed, 25 Mar 2015
                by AricRindfleisch
             </div>
-            [caption id="" align="alignnone" width="720"]<a href="http://images.squarespace-cdn.com/content/v1/59ebf554edaed825d0d8e200/1509139394941-PMIO15G8VH1BWXJVU2SM/Kevin.jpg" ><img src="/images/blog/Kevin.jpg" alt="Kevin"/></a> Kevin[/caption] 
+            [caption id="" align="alignnone" width="720"]<a href="http://images.squarespace-cdn.com/content/v1/59ebf554edaed825d0d8e200/1509139394941-PMIO15G8VH1BWXJVU2SM/Kevin.jpg" ><img src="/makerlab/images/blog/Kevin.jpg" alt="Kevin"/></a> Kevin[/caption] 
   
 
 

--- a/blog/making-things-class-refines-prototypes.html
+++ b/blog/making-things-class-refines-prototypes.html
@@ -42,7 +42,7 @@
               Published on Tue, 01 Apr 2014
                by AricRindfleisch
             </div>
-            [caption id="" align="alignnone" width="2500"]<a href="http://images.squarespace-cdn.com/content/v1/59ebf554edaed825d0d8e200/1509139364046-PAWTFZZ4L4X1GAZLIWQR/photo-64.jpg" ><img src="/images/blog/photo-64.jpg" alt="photo-64"/></a> photo-64[/caption] 
+            [caption id="" align="alignnone" width="2500"]<a href="http://images.squarespace-cdn.com/content/v1/59ebf554edaed825d0d8e200/1509139364046-PAWTFZZ4L4X1GAZLIWQR/photo-64.jpg" ><img src="/makerlab/images/blog/photo-64.jpg" alt="photo-64"/></a> photo-64[/caption] 
   
 
 

--- a/blog/mario-themed-birthday-party.html
+++ b/blog/mario-themed-birthday-party.html
@@ -72,19 +72,19 @@
 <div class="image-gallery-wrapper">
 
   
-   <img src="/images/blog/Birthday-Party.jpg" />
+   <img src="/makerlab/images/blog/Birthday-Party.jpg" />
   
 
   
-   <img src="/images/blog/Birthday-Party-1.jpg" />
+   <img src="/makerlab/images/blog/Birthday-Party-1.jpg" />
   
 
   
-   <img src="/images/blog/Birthday-Party-2.jpg" />
+   <img src="/makerlab/images/blog/Birthday-Party-2.jpg" />
   
 
   
-   <img src="/images/blog/Birthday-Party-3.jpg" />
+   <img src="/makerlab/images/blog/Birthday-Party-3.jpg" />
   
 
   

--- a/blog/meet-gabe-travis.html
+++ b/blog/meet-gabe-travis.html
@@ -71,14 +71,14 @@
 
 
   
-      <img src="/images/blog/Screen_Shot_2019-05-09_at_1.38.18_PM.png" alt=""/>
+      <img src="/makerlab/images/blog/Screen_Shot_2019-05-09_at_1.38.18_PM.png" alt=""/>
   
 
 
 
 
   
-      <img src="/images/blog/Screen_Shot_2019-05-09_at_1.42.02_PM.png" alt=""/>
+      <img src="/makerlab/images/blog/Screen_Shot_2019-05-09_at_1.42.02_PM.png" alt=""/>
   
 
 
@@ -142,7 +142,7 @@
 <div class="image-gallery-wrapper">
 
   
-   <img src="/images/blog/Screen_Shot_2019-05-09_at_1.50.26_PM.png" />
+   <img src="/makerlab/images/blog/Screen_Shot_2019-05-09_at_1.50.26_PM.png" />
   
 
   

--- a/blog/meet-the-maker-adrian-radocea.html
+++ b/blog/meet-the-maker-adrian-radocea.html
@@ -42,7 +42,7 @@
               Published on Sat, 29 Apr 2017
                by GuestUser
             </div>
-            <img src="/images/blog/Adrian-Rodocea.png" alt=""/>
+            <img src="/makerlab/images/blog/Adrian-Rodocea.png" alt=""/>
   
 
 

--- a/blog/meet-the-maker-boyu-ji.html
+++ b/blog/meet-the-maker-boyu-ji.html
@@ -80,11 +80,11 @@
   
 
   
-   <img src="/images/blog/microMsg.1396903371948-e1415896676504.jpg" />
+   <img src="/makerlab/images/blog/microMsg.1396903371948-e1415896676504.jpg" />
   
 
   
-   <img src="/images/blog/microMsg.1396903395510-e1415896657388.jpg" />
+   <img src="/makerlab/images/blog/microMsg.1396903395510-e1415896657388.jpg" />
   
 
   
@@ -92,7 +92,7 @@
   
 
   
-   <img src="/images/blog/microMsg.1396969713962.jpg" />
+   <img src="/makerlab/images/blog/microMsg.1396969713962.jpg" />
   
 
 </div>

--- a/blog/meet-the-maker-fritz.html
+++ b/blog/meet-the-maker-fritz.html
@@ -72,7 +72,7 @@
 <div class="image-gallery-wrapper">
 
   
-   <img src="/images/blog/Fritz-2.JPG" />
+   <img src="/makerlab/images/blog/Fritz-2.JPG" />
   
 
   

--- a/blog/meet-the-maker-i-ning-chen.html
+++ b/blog/meet-the-maker-i-ning-chen.html
@@ -72,7 +72,7 @@
 <div class="image-gallery-wrapper">
 
   
-   <img src="/images/blog/I-Ning-Chen-Print-2.jpg" />
+   <img src="/makerlab/images/blog/I-Ning-Chen-Print-2.jpg" />
   
 
   
@@ -80,11 +80,11 @@
   
 
   
-   <img src="/images/blog/I-Ning-Chen-Print-5.jpg" />
+   <img src="/makerlab/images/blog/I-Ning-Chen-Print-5.jpg" />
   
 
   
-   <img src="/images/blog/I-Ning-Chen-Print-4.jpg" />
+   <img src="/makerlab/images/blog/I-Ning-Chen-Print-4.jpg" />
   
 
 </div>

--- a/blog/meet-the-maker-jacob-holland-a-k-a-iron-man.html
+++ b/blog/meet-the-maker-jacob-holland-a-k-a-iron-man.html
@@ -79,7 +79,7 @@ He says that</p>
   
 
   
-   <img src="/images/blog/Kossel-Clear.jpeg" />
+   <img src="/makerlab/images/blog/Kossel-Clear.jpeg" />
   
 
   

--- a/blog/meet-the-maker-katie-kinley.html
+++ b/blog/meet-the-maker-katie-kinley.html
@@ -78,7 +78,7 @@ Katie Kinley entered this competition as a senior at the University of Illinois 
 <div class="image-gallery-wrapper">
 
   
-   <img src="/images/blog/image1.jpeg" />
+   <img src="/makerlab/images/blog/image1.jpeg" />
   
 
   

--- a/blog/meet-the-maker-mengyang-li.html
+++ b/blog/meet-the-maker-mengyang-li.html
@@ -80,7 +80,7 @@
   
 
   
-   <img src="/images/blog/pic1.jpg" />
+   <img src="/makerlab/images/blog/pic1.jpg" />
   
 
   

--- a/blog/meet-the-maker-nathan.html
+++ b/blog/meet-the-maker-nathan.html
@@ -72,7 +72,7 @@
 <div class="image-gallery-wrapper">
 
   
-   <img src="/images/blog/Tai-Epsilon-1.jpg" />
+   <img src="/makerlab/images/blog/Tai-Epsilon-1.jpg" />
   
 
   
@@ -80,7 +80,7 @@
   
 
   
-   <img src="/images/blog/Tai-Epsilon.jpg" />
+   <img src="/makerlab/images/blog/Tai-Epsilon.jpg" />
   
 
 </div>

--- a/blog/meet-the-maker-reese.html
+++ b/blog/meet-the-maker-reese.html
@@ -73,15 +73,15 @@
 <div class="image-gallery-wrapper">
 
   
-   <img src="/images/blog/Image-October-7-2016-6-36-08-PM-1.jpg" />
+   <img src="/makerlab/images/blog/Image-October-7-2016-6-36-08-PM-1.jpg" />
   
 
   
-   <img src="/images/blog/Image-October-7-2016-6-57-18-PM.jpg" />
+   <img src="/makerlab/images/blog/Image-October-7-2016-6-57-18-PM.jpg" />
   
 
   
-   <img src="/images/blog/reese.jpeg" />
+   <img src="/makerlab/images/blog/reese.jpeg" />
   
 
 </div>

--- a/blog/meet-the-maker-sasha-tetzlaff.html
+++ b/blog/meet-the-maker-sasha-tetzlaff.html
@@ -72,11 +72,11 @@
 <div class="image-gallery-wrapper">
 
   
-   <img src="/images/blog/2018-05-06_13.07.45.jpg" />
+   <img src="/makerlab/images/blog/2018-05-06_13.07.45.jpg" />
   
 
   
-   <img src="/images/blog/2018-04-12_18.47.47.jpg" />
+   <img src="/makerlab/images/blog/2018-04-12_18.47.47.jpg" />
   
 
 </div>

--- a/blog/meet-the-maker-shivani-patel.html
+++ b/blog/meet-the-maker-shivani-patel.html
@@ -72,15 +72,15 @@
 <div class="image-gallery-wrapper">
 
   
-   <img src="/images/blog/Shivani-Patel-2.png" />
+   <img src="/makerlab/images/blog/Shivani-Patel-2.png" />
   
 
   
-   <img src="/images/blog/ShivaniPatel.jpg" />
+   <img src="/makerlab/images/blog/ShivaniPatel.jpg" />
   
 
   
-   <img src="/images/blog/ShivaniPatel-1.jpg" />
+   <img src="/makerlab/images/blog/ShivaniPatel-1.jpg" />
   
 
 </div>

--- a/blog/national-medal-of-science-designed-and-printed-at-the-lab.html
+++ b/blog/national-medal-of-science-designed-and-printed-at-the-lab.html
@@ -77,11 +77,11 @@ Nicholas Vasi, Director of Communications, Institute for Genomic Biology came to
   
 
   
-   <img src="/images/blog/UI-BOT-Medal-sm.jpg" />
+   <img src="/makerlab/images/blog/UI-BOT-Medal-sm.jpg" />
   
 
   
-   <img src="/images/blog/NMS-Medal-sm.jpg" />
+   <img src="/makerlab/images/blog/NMS-Medal-sm.jpg" />
   
 
 </div>
@@ -117,7 +117,7 @@ Nicholas Vasi, Director of Communications, Institute for Genomic Biology came to
 <div class="image-gallery-wrapper">
 
   
-   <img src="/images/blog/Screen-Shot-2015-02-13-at-3.03.45-PM.png" />
+   <img src="/makerlab/images/blog/Screen-Shot-2015-02-13-at-3.03.45-PM.png" />
   
 
   
@@ -125,7 +125,7 @@ Nicholas Vasi, Director of Communications, Institute for Genomic Biology came to
   
 
   
-   <img src="/images/blog/IMG_0247.jpg" />
+   <img src="/makerlab/images/blog/IMG_0247.jpg" />
   
 
   

--- a/blog/new-year-brings-new-printers.html
+++ b/blog/new-year-brings-new-printers.html
@@ -42,7 +42,7 @@
               Published on Wed, 06 Jan 2016
                by AricRindfleisch
             </div>
-            [caption id="" align="alignnone" width="2448"]<a href="http://images.squarespace-cdn.com/content/v1/59ebf554edaed825d0d8e200/1509139424706-22M4UQE9ZX4XHOAKQUG5/MakerBot-1.jpg" ><img src="/images/blog/MakerBot-1.jpg" alt="MakerBot 1"/></a> MakerBot 1[/caption] 
+            [caption id="" align="alignnone" width="2448"]<a href="http://images.squarespace-cdn.com/content/v1/59ebf554edaed825d0d8e200/1509139424706-22M4UQE9ZX4XHOAKQUG5/MakerBot-1.jpg" ><img src="/makerlab/images/blog/MakerBot-1.jpg" alt="MakerBot 1"/></a> MakerBot 1[/caption] 
   
 
 

--- a/blog/online-summer-camps-2020.html
+++ b/blog/online-summer-camps-2020.html
@@ -76,7 +76,7 @@
   
 
   
-   <img src="/images/general/Untitled.jpg" />
+   <img src="/makerlab/images/general/Untitled.jpg" />
   
 
 </div>

--- a/blog/physics-department-class.html
+++ b/blog/physics-department-class.html
@@ -71,7 +71,7 @@
 
 
   
-      <img src="/images/blog/p398DLP_prints.jpg" alt=""/>
+      <img src="/makerlab/images/blog/p398DLP_prints.jpg" alt=""/>
   
 
 
@@ -87,7 +87,7 @@
   
 
   
-   <img src="/images/blog/Image_October_31__2018_11_52_13_AM__1_.jpg" />
+   <img src="/makerlab/images/blog/Image_October_31__2018_11_52_13_AM__1_.jpg" />
   
 
 </div>

--- a/blog/ping-fu-visits-the-makerlab.html
+++ b/blog/ping-fu-visits-the-makerlab.html
@@ -73,7 +73,7 @@ Here are some pictures of her visit.</p>
 <div class="image-gallery-wrapper">
 
   
-   <img src="/images/blog/IMG_20131111_150004-e1388468202799.jpg" />
+   <img src="/makerlab/images/blog/IMG_20131111_150004-e1388468202799.jpg" />
   
 
   

--- a/blog/printing-testing-redesigning-repeat-making-things-class.html
+++ b/blog/printing-testing-redesigning-repeat-making-things-class.html
@@ -42,7 +42,7 @@
               Published on Wed, 08 Apr 2015
                by AricRindfleisch
             </div>
-            [caption id="" align="alignnone" width="2500"]<a href="http://images.squarespace-cdn.com/content/v1/59ebf554edaed825d0d8e200/1509139403823-3FD7YRMMBGUTTBYR89NH/Team-Digicraft.jpg" ><img src="/images/blog/Team-Digicraft.jpg" alt="Team Digicraft"/></a> Team Digicraft[/caption] 
+            [caption id="" align="alignnone" width="2500"]<a href="http://images.squarespace-cdn.com/content/v1/59ebf554edaed825d0d8e200/1509139403823-3FD7YRMMBGUTTBYR89NH/Team-Digicraft.jpg" ><img src="/makerlab/images/blog/Team-Digicraft.jpg" alt="Team Digicraft"/></a> Team Digicraft[/caption] 
   
 
 

--- a/blog/prototyping-and-design-digital-making-2017.html
+++ b/blog/prototyping-and-design-digital-making-2017.html
@@ -83,7 +83,7 @@
   
 
   
-   <img src="/images/blog/Prototyping-and-Design-2.jpg" />
+   <img src="/makerlab/images/blog/Prototyping-and-Design-2.jpg" />
   
 
 </div>

--- a/blog/pygmalion-tech-demo.html
+++ b/blog/pygmalion-tech-demo.html
@@ -42,7 +42,7 @@
               Published on Mon, 02 Oct 2017
                by GuestUser
             </div>
-            <img src="/images/blog/Tech-Demo.jpg" alt=""/>
+            <img src="/makerlab/images/blog/Tech-Demo.jpg" alt=""/>
   
 
 

--- a/blog/replica-of-nobel-prize-medallion.html
+++ b/blog/replica-of-nobel-prize-medallion.html
@@ -72,19 +72,19 @@
 <div class="image-gallery-wrapper">
 
   
-   <img src="/images/blog/Image_September_26__2019_09_33_24.jpg" />
+   <img src="/makerlab/images/blog/Image_September_26__2019_09_33_24.jpg" />
   
 
   
-   <img src="/images/blog/Image_September_30__2019_17_01_55.jpg" />
+   <img src="/makerlab/images/blog/Image_September_30__2019_17_01_55.jpg" />
   
 
   
-   <img src="/images/blog/images.squarespace-cdn.com-1.jpg" />
+   <img src="/makerlab/images/blog/images.squarespace-cdn.com-1.jpg" />
   
 
   
-   <img src="/images/blog/images.squarespace-cdn.com.jpg" />
+   <img src="/makerlab/images/blog/images.squarespace-cdn.com.jpg" />
   
 
 </div>

--- a/blog/scanning-and-prototyping-digital-making-2017.html
+++ b/blog/scanning-and-prototyping-digital-making-2017.html
@@ -76,7 +76,7 @@
   
 
   
-   <img src="/images/general/Digital-Making-Week-10-2.jpg" />
+   <img src="/makerlab/images/general/Digital-Making-Week-10-2.jpg" />
   
 
 </div>
@@ -112,7 +112,7 @@
 <div class="image-gallery-wrapper">
 
   
-   <img src="/images/blog/Digital-Making-Week-10-3-1.jpg" />
+   <img src="/makerlab/images/blog/Digital-Making-Week-10-3-1.jpg" />
   
 
   
@@ -120,7 +120,7 @@
   
 
   
-   <img src="/images/blog/Digital-Making-Week-10-5.jpg" />
+   <img src="/makerlab/images/blog/Digital-Making-Week-10-5.jpg" />
   
 
 </div>

--- a/blog/session-1-of-3-day-hs-robotics-3d-workshop-huge-success.html
+++ b/blog/session-1-of-3-day-hs-robotics-3d-workshop-huge-success.html
@@ -76,7 +76,7 @@
 
 
   
-       [caption id="" align="alignnone" width="2048"]<a href="http://images.squarespace-cdn.com/content/v1/59ebf554edaed825d0d8e200/1509139411546-VOCGDZOVZD7N1FTNLJOR/Student_Coding.jpg" ><img src="/images/blog/Student_Coding.jpg" alt="Student_Coding"/></a> Student_Coding[/caption] 
+       [caption id="" align="alignnone" width="2048"]<a href="http://images.squarespace-cdn.com/content/v1/59ebf554edaed825d0d8e200/1509139411546-VOCGDZOVZD7N1FTNLJOR/Student_Coding.jpg" ><img src="/makerlab/images/blog/Student_Coding.jpg" alt="Student_Coding"/></a> Student_Coding[/caption] 
   
 
 
@@ -110,7 +110,7 @@
 
 
   
-       [caption id="" align="alignnone" width="2048"]<a href="http://images.squarespace-cdn.com/content/v1/59ebf554edaed825d0d8e200/1509139411946-QRYSVFLHJD256PV4WOW7/Viewing-3D-Printing.jpg" ><img src="/images/blog/Viewing-3D-Printing.jpg" alt="Viewing 3D Printing"/></a> Viewing 3D Printing[/caption] 
+       [caption id="" align="alignnone" width="2048"]<a href="http://images.squarespace-cdn.com/content/v1/59ebf554edaed825d0d8e200/1509139411946-QRYSVFLHJD256PV4WOW7/Viewing-3D-Printing.jpg" ><img src="/makerlab/images/blog/Viewing-3D-Printing.jpg" alt="Viewing 3D Printing"/></a> Viewing 3D Printing[/caption] 
   
 
 

--- a/blog/sharing-our-learning-from-the-making-things-course.html
+++ b/blog/sharing-our-learning-from-the-making-things-course.html
@@ -45,7 +45,7 @@
             <div class="image-gallery-wrapper">
 
   
-   <img src="/images/blog/IMG_20150211_124622.jpg" />
+   <img src="/makerlab/images/blog/IMG_20150211_124622.jpg" />
   
 
   

--- a/blog/souvenirs-for-women-in-engineering-3d-printed.html
+++ b/blog/souvenirs-for-women-in-engineering-3d-printed.html
@@ -42,7 +42,7 @@
               Published on Mon, 27 Apr 2015
                by uimakerlab@illinois.edu
             </div>
-            <img src="/images/blog/B-kLLFeIMAA-hbE.jpg" alt=""/>
+            <img src="/makerlab/images/blog/B-kLLFeIMAA-hbE.jpg" alt=""/>
   
 
 

--- a/blog/spring-break-is-a-great-time-to-order-online.html
+++ b/blog/spring-break-is-a-great-time-to-order-online.html
@@ -72,15 +72,15 @@
 <div class="image-gallery-wrapper">
 
   
-   <img src="/images/blog/3D-Hubs.png" />
+   <img src="/makerlab/images/blog/3D-Hubs.png" />
   
 
   
-   <img src="/images/blog/Skull-1.jpg" />
+   <img src="/makerlab/images/blog/Skull-1.jpg" />
   
 
   
-   <img src="/images/blog/3D-Hubs-2.png" />
+   <img src="/makerlab/images/blog/3D-Hubs-2.png" />
   
 
 </div>

--- a/blog/the-evolutionary-development-of-man-max.html
+++ b/blog/the-evolutionary-development-of-man-max.html
@@ -81,7 +81,7 @@
   
 
   
-   <img src="/images/blog/max5.png" />
+   <img src="/makerlab/images/blog/max5.png" />
   
 
   
@@ -89,7 +89,7 @@
   
 
   
-   <img src="/images/blog/max3.png" />
+   <img src="/makerlab/images/blog/max3.png" />
   
 
   

--- a/blog/the-makerbots-are-here.html
+++ b/blog/the-makerbots-are-here.html
@@ -81,7 +81,7 @@ Here are some pictures from the unboxing and setup. For more pictures, check out
   
 
   
-   <img src="/images/blog/P1010044.jpg" />
+   <img src="/makerlab/images/blog/P1010044.jpg" />
   
 
   
@@ -89,15 +89,15 @@ Here are some pictures from the unboxing and setup. For more pictures, check out
   
 
   
-   <img src="/images/blog/IMG_20130109_155711.jpg" />
+   <img src="/makerlab/images/blog/IMG_20130109_155711.jpg" />
   
 
   
-   <img src="/images/blog/IMG_20130109_160521.jpg" />
+   <img src="/makerlab/images/blog/IMG_20130109_160521.jpg" />
   
 
   
-   <img src="/images/blog/IMG_20130109_154745.jpg" />
+   <img src="/makerlab/images/blog/IMG_20130109_154745.jpg" />
   
 
 </div>

--- a/blog/this-week-of-making-week-6.html
+++ b/blog/this-week-of-making-week-6.html
@@ -76,7 +76,7 @@
   
 
   
-   <img src="/images/general/Valentines-Day-2.jpg" />
+   <img src="/makerlab/images/general/Valentines-Day-2.jpg" />
   
 
 </div>
@@ -112,15 +112,15 @@
 <div class="image-gallery-wrapper">
 
   
-   <img src="/images/blog/Dragon-Box.jpg" />
+   <img src="/makerlab/images/blog/Dragon-Box.jpg" />
   
 
   
-   <img src="/images/general/Hippo.jpg" />
+   <img src="/makerlab/images/general/Hippo.jpg" />
   
 
   
-   <img src="/images/general/Carabiners.jpg" />
+   <img src="/makerlab/images/general/Carabiners.jpg" />
   
 
 </div>

--- a/blog/this-week-of-making-week-7.html
+++ b/blog/this-week-of-making-week-7.html
@@ -72,7 +72,7 @@
 <div class="image-gallery-wrapper">
 
   
-   <img src="/images/blog/ICBC.jpg" />
+   <img src="/makerlab/images/blog/ICBC.jpg" />
   
 
   
@@ -112,11 +112,11 @@
 <div class="image-gallery-wrapper">
 
   
-   <img src="/images/general/Order-Online-e1487546902493.jpg" />
+   <img src="/makerlab/images/general/Order-Online-e1487546902493.jpg" />
   
 
   
-   <img src="/images/blog/AutoFusion-1.jpg" />
+   <img src="/makerlab/images/blog/AutoFusion-1.jpg" />
   
 
   

--- a/blog/this-week-of-making-week-8.html
+++ b/blog/this-week-of-making-week-8.html
@@ -72,7 +72,7 @@
 <div class="image-gallery-wrapper">
 
   
-   <img src="/images/general/Mini-Figures.jpg" />
+   <img src="/makerlab/images/general/Mini-Figures.jpg" />
   
 
   
@@ -115,7 +115,7 @@
 
 
   
-      <img src="/images/blog/Scanning-Workshop-e1487973233626.jpg" alt=""/>
+      <img src="/makerlab/images/blog/Scanning-Workshop-e1487973233626.jpg" alt=""/>
   
 
 

--- a/blog/this-week-of-making-week42.html
+++ b/blog/this-week-of-making-week42.html
@@ -42,7 +42,7 @@
               Published on Wed, 12 Oct 2016
                by GuestUser
             </div>
-            <img src="/images/blog/Parts.jpg" alt=""/>
+            <img src="/makerlab/images/blog/Parts.jpg" alt=""/>
   
 
 
@@ -76,14 +76,14 @@
 
 
   
-      <a href="https://twitter.com/hashtag/printaperson?src=has" ><img src="/images/blog/Parts.jpg" alt=""/></a>
+      <a href="https://twitter.com/hashtag/printaperson?src=has" ><img src="/makerlab/images/blog/Parts.jpg" alt=""/></a>
   
 
 
 
 
   
-       [caption id="" align="alignnone" width="1200"]<a href="https://twitter.com/hashtag/printaperson?src=hash" ><img src="/images/blog/Arms.jpg" alt="arms"/></a> arms[/caption] 
+       [caption id="" align="alignnone" width="1200"]<a href="https://twitter.com/hashtag/printaperson?src=hash" ><img src="/makerlab/images/blog/Arms.jpg" alt="arms"/></a> arms[/caption] 
   
 
 
@@ -117,14 +117,14 @@
 
 
   
-       [caption id="" align="alignnone" width="1024"]<a href="https://pbs.twimg.com/media/Csq-v9uWEAALYwc.jpg" ><img src="/images/blog/LegsArms.jpg" alt="legsarms"/></a> legsarms[/caption] 
+       [caption id="" align="alignnone" width="1024"]<a href="https://pbs.twimg.com/media/Csq-v9uWEAALYwc.jpg" ><img src="/makerlab/images/blog/LegsArms.jpg" alt="legsarms"/></a> legsarms[/caption] 
   
 
 
 
 
   
-       [caption id="" align="alignnone" width="1024"]<img src="/images/blog/Head.jpg" alt="head"/> head[/caption] 
+       [caption id="" align="alignnone" width="1024"]<img src="/makerlab/images/blog/Head.jpg" alt="head"/> head[/caption] 
   
 
 
@@ -158,7 +158,7 @@
 
 
   
-       [caption id="" align="alignnone" width="480"]<img src="/images/blog/Hallene-Gateway.jpg" alt="hallene-gateway"/> hallene-gateway[/caption] 
+       [caption id="" align="alignnone" width="480"]<img src="/makerlab/images/blog/Hallene-Gateway.jpg" alt="hallene-gateway"/> hallene-gateway[/caption] 
   
 
 
@@ -294,14 +294,14 @@
 
 
   
-       [caption id="" align="alignnone" width="614"]<img src="/images/blog/Certificates.jpg" alt="certificates"/> certificates[/caption] 
+       [caption id="" align="alignnone" width="614"]<img src="/makerlab/images/blog/Certificates.jpg" alt="certificates"/> certificates[/caption] 
   
 
 
 
 
   
-       [caption id="" align="alignnone" width="2500"]<img src="/images/blog/Workshop3-1.jpg" alt="workshop3"/> workshop3[/caption] 
+       [caption id="" align="alignnone" width="2500"]<img src="/makerlab/images/blog/Workshop3-1.jpg" alt="workshop3"/> workshop3[/caption] 
   
 
 
@@ -342,21 +342,21 @@
 
 
   
-       [caption id="" align="alignnone" width="1200"]<img src="/images/blog/Harry-Potter-Glasses.jpg" alt="harry-potter-glasses"/> harry-potter-glasses[/caption] 
+       [caption id="" align="alignnone" width="1200"]<img src="/makerlab/images/blog/Harry-Potter-Glasses.jpg" alt="harry-potter-glasses"/> harry-potter-glasses[/caption] 
   
 
 
 
 
   
-       [caption id="" align="alignnone" width="750"]<img src="/images/blog/Dragon.jpg" alt="dragon"/> dragon[/caption] 
+       [caption id="" align="alignnone" width="750"]<img src="/makerlab/images/blog/Dragon.jpg" alt="dragon"/> dragon[/caption] 
   
 
 
 
 
   
-       [caption id="" align="alignnone" width="2500"]<img src="/images/blog/US-Navy.jpg" alt="us-navy"/> us-navy[/caption] 
+       [caption id="" align="alignnone" width="2500"]<img src="/makerlab/images/blog/US-Navy.jpg" alt="us-navy"/> us-navy[/caption] 
   
 
 
@@ -397,7 +397,7 @@
 
 
   
-       [caption id="" align="alignnone" width="1920"]<img src="/images/blog/Image-October-7-2016-3-44-11-PM-1.jpg" alt="image-october-7-2016-3-44-11-pm-1"/> image-october-7-2016-3-44-11-pm-1[/caption] 
+       [caption id="" align="alignnone" width="1920"]<img src="/makerlab/images/blog/Image-October-7-2016-3-44-11-PM-1.jpg" alt="image-october-7-2016-3-44-11-pm-1"/> image-october-7-2016-3-44-11-pm-1[/caption] 
   
 
 

--- a/blog/this-week-of-making-week43.html
+++ b/blog/this-week-of-making-week43.html
@@ -72,7 +72,7 @@
 <div class="image-gallery-wrapper">
 
   
-   <img src="/images/blog/Torso.jpg" />
+   <img src="/makerlab/images/blog/Torso.jpg" />
   
 
   
@@ -117,7 +117,7 @@
 <div class="image-gallery-wrapper">
 
   
-   <img src="/images/blog/Right-Profile-of-Head.jpg" />
+   <img src="/makerlab/images/blog/Right-Profile-of-Head.jpg" />
   
 
   
@@ -167,7 +167,7 @@
 <div class="image-gallery-wrapper">
 
   
-   <img src="/images/blog/Minecraft-1.jpg" />
+   <img src="/makerlab/images/blog/Minecraft-1.jpg" />
   
 
   
@@ -175,11 +175,11 @@
   
 
   
-   <img src="/images/blog/Minecraft-3.jpg" />
+   <img src="/makerlab/images/blog/Minecraft-3.jpg" />
   
 
   
-   <img src="/images/blog/Minecraft-4.jpg" />
+   <img src="/makerlab/images/blog/Minecraft-4.jpg" />
   
 
   
@@ -233,7 +233,7 @@
   
 
   
-   <img src="/images/blog/TinderCad-4.jpg" />
+   <img src="/makerlab/images/blog/TinderCad-4.jpg" />
   
 
   
@@ -241,7 +241,7 @@
   
 
   
-   <img src="/images/blog/TinderCad-5.jpg" />
+   <img src="/makerlab/images/blog/TinderCad-5.jpg" />
   
 
 </div>
@@ -278,19 +278,19 @@
 <div class="image-gallery-wrapper">
 
   
-   <img src="/images/blog/Building-2.jpg" />
+   <img src="/makerlab/images/blog/Building-2.jpg" />
   
 
   
-   <img src="/images/blog/Building-1.jpg" />
+   <img src="/makerlab/images/blog/Building-1.jpg" />
   
 
   
-   <img src="/images/blog/Building-3.jpg" />
+   <img src="/makerlab/images/blog/Building-3.jpg" />
   
 
   
-   <img src="/images/blog/Building-4.jpg" />
+   <img src="/makerlab/images/blog/Building-4.jpg" />
   
 
   

--- a/blog/this-week-of-making-week44.html
+++ b/blog/this-week-of-making-week44.html
@@ -80,7 +80,7 @@
   
 
   
-   <img src="/images/blog/Pic-with-Max-2.jpg" />
+   <img src="/makerlab/images/blog/Pic-with-Max-2.jpg" />
   
 
 </div>
@@ -118,7 +118,7 @@
 <div class="image-gallery-wrapper">
 
   
-   <img src="/images/general/Ultimaker3-3.jpg" />
+   <img src="/makerlab/images/general/Ultimaker3-3.jpg" />
   
 
   
@@ -126,7 +126,7 @@
   
 
   
-   <img src="/images/blog/Dual-Printing.jpg" />
+   <img src="/makerlab/images/blog/Dual-Printing.jpg" />
   
 
 </div>
@@ -165,7 +165,7 @@
 <div class="image-gallery-wrapper">
 
   
-   <img src="/images/blog/Altgeld-Hall-Provost-Office.jpg" />
+   <img src="/makerlab/images/blog/Altgeld-Hall-Provost-Office.jpg" />
   
 
   
@@ -173,7 +173,7 @@
   
 
   
-   <img src="/images/blog/Hallene-Gateway-Provost-Office.jpg" />
+   <img src="/makerlab/images/blog/Hallene-Gateway-Provost-Office.jpg" />
   
 
 </div>
@@ -226,7 +226,7 @@
   
 
   
-   <img src="/images/blog/Allison-Nowak-4-1.jpg" />
+   <img src="/makerlab/images/blog/Allison-Nowak-4-1.jpg" />
   
 
 </div>

--- a/blog/this-week-of-making-week45.html
+++ b/blog/this-week-of-making-week45.html
@@ -76,11 +76,11 @@
   
 
   
-   <img src="/images/blog/BC-4.jpg" />
+   <img src="/makerlab/images/blog/BC-4.jpg" />
   
 
   
-   <img src="/images/blog/BC-2-1.jpg" />
+   <img src="/makerlab/images/blog/BC-2-1.jpg" />
   
 
   
@@ -120,7 +120,7 @@
 <div class="image-gallery-wrapper">
 
   
-   <img src="/images/blog/HS-1.jpg" />
+   <img src="/makerlab/images/blog/HS-1.jpg" />
   
 
   
@@ -132,11 +132,11 @@
   
 
   
-   <img src="/images/blog/HS-5.jpg" />
+   <img src="/makerlab/images/blog/HS-5.jpg" />
   
 
   
-   <img src="/images/blog/HS-6.jpg" />
+   <img src="/makerlab/images/blog/HS-6.jpg" />
   
 
   
@@ -182,7 +182,7 @@
   
 
   
-   <img src="/images/blog/Car-Print-2.jpg" />
+   <img src="/makerlab/images/blog/Car-Print-2.jpg" />
   
 
   
@@ -190,7 +190,7 @@
   
 
   
-   <img src="/images/blog/Car-Print-4.jpg" />
+   <img src="/makerlab/images/blog/Car-Print-4.jpg" />
   
 
 </div>
@@ -225,7 +225,7 @@
 
 
   
-       [caption id="" align="alignnone" width="1435"]<img src="/images/blog/Food-Printer-2.jpg" alt="food-printer-2"/> food-printer-2[/caption] 
+       [caption id="" align="alignnone" width="1435"]<img src="/makerlab/images/blog/Food-Printer-2.jpg" alt="food-printer-2"/> food-printer-2[/caption] 
   
 
 

--- a/blog/this-week-of-making-week46.html
+++ b/blog/this-week-of-making-week46.html
@@ -76,7 +76,7 @@
   
 
   
-   <img src="/images/blog/Max-4.jpg" />
+   <img src="/makerlab/images/blog/Max-4.jpg" />
   
 
   
@@ -92,7 +92,7 @@
   
 
   
-   <img src="/images/blog/Max-7-1.jpg" />
+   <img src="/makerlab/images/blog/Max-7-1.jpg" />
   
 
 </div>
@@ -132,11 +132,11 @@
   
 
   
-   <img src="/images/blog/Nov5-8.jpg" />
+   <img src="/makerlab/images/blog/Nov5-8.jpg" />
   
 
   
-   <img src="/images/blog/Nov5-9.jpg" />
+   <img src="/makerlab/images/blog/Nov5-9.jpg" />
   
 
   
@@ -144,7 +144,7 @@
   
 
   
-   <img src="/images/blog/Nov5-12.jpg" />
+   <img src="/makerlab/images/blog/Nov5-12.jpg" />
   
 
   
@@ -152,15 +152,15 @@
   
 
   
-   <img src="/images/blog/Nov5-5.jpg" />
+   <img src="/makerlab/images/blog/Nov5-5.jpg" />
   
 
   
-   <img src="/images/blog/Nov5-10.jpg" />
+   <img src="/makerlab/images/blog/Nov5-10.jpg" />
   
 
   
-   <img src="/images/blog/Nov5-13-1.jpg" />
+   <img src="/makerlab/images/blog/Nov5-13-1.jpg" />
   
 
   
@@ -168,11 +168,11 @@
   
 
   
-   <img src="/images/blog/Nov5-4.jpg" />
+   <img src="/makerlab/images/blog/Nov5-4.jpg" />
   
 
   
-   <img src="/images/blog/Nov5-2-2.jpg" />
+   <img src="/makerlab/images/blog/Nov5-2-2.jpg" />
   
 
 </div>

--- a/blog/this-week-of-making-week47.html
+++ b/blog/this-week-of-making-week47.html
@@ -77,15 +77,15 @@
   
 
   
-   <img src="/images/blog/Build-Max-7.jpg" />
+   <img src="/makerlab/images/blog/Build-Max-7.jpg" />
   
 
   
-   <img src="/images/blog/Build-Max-6.jpg" />
+   <img src="/makerlab/images/blog/Build-Max-6.jpg" />
   
 
   
-   <img src="/images/blog/Build-Max-5.jpg" />
+   <img src="/makerlab/images/blog/Build-Max-5.jpg" />
   
 
   
@@ -101,7 +101,7 @@
   
 
   
-   <img src="/images/general/Build-Max-10.jpg" />
+   <img src="/makerlab/images/general/Build-Max-10.jpg" />
   
 
   
@@ -158,11 +158,11 @@
   
 
   
-   <img src="/images/blog/Deloitte-Chairman-2.jpg" />
+   <img src="/makerlab/images/blog/Deloitte-Chairman-2.jpg" />
   
 
   
-   <img src="/images/blog/Deloitte-Chairman-1-1.jpg" />
+   <img src="/makerlab/images/blog/Deloitte-Chairman-1-1.jpg" />
   
 
 </div>
@@ -207,7 +207,7 @@
   
 
   
-   <img src="/images/blog/Food-Printer-5.jpg" />
+   <img src="/makerlab/images/blog/Food-Printer-5.jpg" />
   
 
 </div>
@@ -252,7 +252,7 @@
   
 
   
-   <img src="/images/general/Birthday-Card-1.jpg" />
+   <img src="/makerlab/images/general/Birthday-Card-1.jpg" />
   
 
   
@@ -260,7 +260,7 @@
   
 
   
-   <img src="/images/blog/Trumpet-Mouth-Piece.jpg" />
+   <img src="/makerlab/images/blog/Trumpet-Mouth-Piece.jpg" />
   
 
 </div>

--- a/blog/tremendous-interest-in-the-makerlab-open-house.html
+++ b/blog/tremendous-interest-in-the-makerlab-open-house.html
@@ -42,7 +42,7 @@
               Published on Sun, 10 Feb 2013
                by VishalSachdev
             </div>
-            <img src="/images/blog/IMG_1937-2.jpg" alt=""/>
+            <img src="/makerlab/images/blog/IMG_1937-2.jpg" alt=""/>
   
 
 

--- a/blog/try-our-new-flexible-filament.html
+++ b/blog/try-our-new-flexible-filament.html
@@ -42,7 +42,7 @@
               Published on Thu, 07 Aug 2014
                by AricRindfleisch
             </div>
-            [caption id="" align="alignnone" width="2500"]<a href="http://images.squarespace-cdn.com/content/v1/59ebf554edaed825d0d8e200/1509139371135-QXGU9A8DHGCLIDGV3337/Flex-Filament-2-e1405865307184.jpg" ><img src="/images/blog/Flex-Filament-2-e1405865307184.jpg" alt="Flex Filament 2"/></a> Flex Filament 2[/caption] 
+            [caption id="" align="alignnone" width="2500"]<a href="http://images.squarespace-cdn.com/content/v1/59ebf554edaed825d0d8e200/1509139371135-QXGU9A8DHGCLIDGV3337/Flex-Filament-2-e1405865307184.jpg" ><img src="/makerlab/images/blog/Flex-Filament-2-e1405865307184.jpg" alt="Flex Filament 2"/></a> Flex Filament 2[/caption] 
   
 
 

--- a/blog/tv-b-gone-with-mitch-altman.html
+++ b/blog/tv-b-gone-with-mitch-altman.html
@@ -49,7 +49,7 @@
   
 
   
-   <img src="/images/blog/TV-1.jpg" />
+   <img src="/makerlab/images/blog/TV-1.jpg" />
   
 
   
@@ -57,11 +57,11 @@
   
 
   
-   <img src="/images/blog/TV-3.jpg" />
+   <img src="/makerlab/images/blog/TV-3.jpg" />
   
 
   
-   <img src="/images/blog/TV-4.jpg" />
+   <img src="/makerlab/images/blog/TV-4.jpg" />
   
 
   

--- a/blog/volunteer-reflection-jakob-lteif.html
+++ b/blog/volunteer-reflection-jakob-lteif.html
@@ -71,7 +71,7 @@
 
 
   
-      <img src="/images/blog/lteif_headshot.jpg" alt=""/>
+      <img src="/makerlab/images/blog/lteif_headshot.jpg" alt=""/>
   
 
 

--- a/blog/volunteer-spotlight-dash-kosaka.html
+++ b/blog/volunteer-spotlight-dash-kosaka.html
@@ -42,7 +42,7 @@
               Published on Fri, 11 Nov 2016
                by GuestUser
             </div>
-            [caption id="" align="alignnone" width="1309"]<img src="/images/blog/Dash.jpg" alt="dash"/> dash[/caption] 
+            [caption id="" align="alignnone" width="1309"]<img src="/makerlab/images/blog/Dash.jpg" alt="dash"/> dash[/caption] 
   
 
 
@@ -82,15 +82,15 @@
   
 
   
-   <img src="/images/blog/Dash-3.jpg" />
+   <img src="/makerlab/images/blog/Dash-3.jpg" />
   
 
   
-   <img src="/images/blog/Dash-4.jpg" />
+   <img src="/makerlab/images/blog/Dash-4.jpg" />
   
 
   
-   <img src="/images/blog/Dash-5.jpg" />
+   <img src="/makerlab/images/blog/Dash-5.jpg" />
   
 
   

--- a/blog/volunteer-spotlight-jean-padon.html
+++ b/blog/volunteer-spotlight-jean-padon.html
@@ -71,7 +71,7 @@
 
 
   
-      <img src="/images/blog/Jean_headshot.jpg" alt=""/>
+      <img src="/makerlab/images/blog/Jean_headshot.jpg" alt=""/>
   
 
 

--- a/blog/volunteer-spotlight-tony-kim.html
+++ b/blog/volunteer-spotlight-tony-kim.html
@@ -71,7 +71,7 @@
 
 
   
-      <img src="/images/blog/여권사진.jpg" alt=""/>
+      <img src="/makerlab/images/blog/여권사진.jpg" alt=""/>
   
 
 
@@ -110,11 +110,11 @@
   
 
   
-   <img src="/images/blog/mask.jpg" />
+   <img src="/makerlab/images/blog/mask.jpg" />
   
 
   
-   <img src="/images/blog/raptor.jpg" />
+   <img src="/makerlab/images/blog/raptor.jpg" />
   
 
 </div>

--- a/blog/volunteer-spotlight-vanessa-yang.html
+++ b/blog/volunteer-spotlight-vanessa-yang.html
@@ -42,7 +42,7 @@
               Published on Tue, 26 Sep 2017
                by GuestUser
             </div>
-            <img src="/images/blog/unnamed-e1506456176655.png" alt=""/>
+            <img src="/makerlab/images/blog/unnamed-e1506456176655.png" alt=""/>
   
 
 

--- a/blog/volunteer-spotlight-will-jones.html
+++ b/blog/volunteer-spotlight-will-jones.html
@@ -80,19 +80,19 @@
   
 
   
-   <img src="/images/blog/Will-3.jpg" />
+   <img src="/makerlab/images/blog/Will-3.jpg" />
   
 
   
-   <img src="/images/blog/Will-4.jpg" />
+   <img src="/makerlab/images/blog/Will-4.jpg" />
   
 
   
-   <img src="/images/blog/Will-8.jpg" />
+   <img src="/makerlab/images/blog/Will-8.jpg" />
   
 
   
-   <img src="/images/blog/Will-9.jpg" />
+   <img src="/makerlab/images/blog/Will-9.jpg" />
   
 
 </div>
@@ -130,7 +130,7 @@
 <div class="image-gallery-wrapper">
 
   
-   <img src="/images/blog/Will-5.jpg" />
+   <img src="/makerlab/images/blog/Will-5.jpg" />
   
 
   

--- a/blog/volunteer-spotlight-yuxuan-tang.html
+++ b/blog/volunteer-spotlight-yuxuan-tang.html
@@ -71,7 +71,7 @@
 
 
   
-      <img src="/images/blog/Yuxuan.jpg" alt=""/>
+      <img src="/makerlab/images/blog/Yuxuan.jpg" alt=""/>
   
 
 

--- a/blog/watch-a-3d-printer-being-built-in-the-bif-atrium.html
+++ b/blog/watch-a-3d-printer-being-built-in-the-bif-atrium.html
@@ -84,7 +84,7 @@
   
 
   
-   <img src="/images/blog/IMG_20160328_154144279.jpg" />
+   <img src="/makerlab/images/blog/IMG_20160328_154144279.jpg" />
   
 
   
@@ -92,7 +92,7 @@
   
 
   
-   <img src="/images/blog/IMG_20160328_154317214.jpg" />
+   <img src="/makerlab/images/blog/IMG_20160328_154317214.jpg" />
   
 
   
@@ -100,7 +100,7 @@
   
 
   
-   <img src="/images/blog/IMG_20160328_160349473.jpg" />
+   <img src="/makerlab/images/blog/IMG_20160328_160349473.jpg" />
   
 
   
@@ -112,7 +112,7 @@
   
 
   
-   <img src="/images/blog/IMG_20160328_172056887.jpg" />
+   <img src="/makerlab/images/blog/IMG_20160328_172056887.jpg" />
   
 
 </div>
@@ -147,7 +147,7 @@
 
 
   
-       [caption id="" align="alignnone" width="2500"]<img src="/images/blog/MakerLab_3DP-Expo.jpg" alt="MakerLab_3DP Expo"/> MakerLab_3DP Expo[/caption]
+       [caption id="" align="alignnone" width="2500"]<img src="/makerlab/images/blog/MakerLab_3DP-Expo.jpg" alt="MakerLab_3DP Expo"/> MakerLab_3DP Expo[/caption]
             <div class="mt-3">
               <a href="/makerlab/blog/index.html" class="btn btn-secondary">← Back to Blog</a>
             </div>

--- a/blog/we-are-no-longer-alone.html
+++ b/blog/we-are-no-longer-alone.html
@@ -42,7 +42,7 @@
               Published on Tue, 16 Feb 2016
                by AricRindfleisch
             </div>
-            [caption id="" align="alignnone" width="960"]<img src="/images/blog/Yonsei-Design-Garage.jpg" alt="Yonsei Design Garage"/> Yonsei Design Garage[/caption] 
+            [caption id="" align="alignnone" width="960"]<img src="/makerlab/images/blog/Yonsei-Design-Garage.jpg" alt="Yonsei Design Garage"/> Yonsei Design Garage[/caption] 
   
 
 

--- a/blog/wearegies.html
+++ b/blog/wearegies.html
@@ -72,11 +72,11 @@
 <div class="image-gallery-wrapper">
 
   
-   <img src="/images/blog/Keychain_Order_.jpg" />
+   <img src="/makerlab/images/blog/Keychain_Order_.jpg" />
   
 
   
-   <img src="/images/blog/wearegies-4.jpg" />
+   <img src="/makerlab/images/blog/wearegies-4.jpg" />
   
 
 </div>

--- a/blog/welcome-back-2.html
+++ b/blog/welcome-back-2.html
@@ -114,7 +114,7 @@
   
 
   
-   <img src="/images/blog/Fidget-Spinner-1.jpg" />
+   <img src="/makerlab/images/blog/Fidget-Spinner-1.jpg" />
   
 
 </div>
@@ -159,7 +159,7 @@
   
 
   
-   <img src="/images/blog/Drone.jpg" />
+   <img src="/makerlab/images/blog/Drone.jpg" />
   
 
 </div>

--- a/blog/were-back-in-business-for-fall-2015.html
+++ b/blog/were-back-in-business-for-fall-2015.html
@@ -71,7 +71,7 @@
 
 
   
-       [caption id="" align="alignnone" width="599"]<a href="http://images.squarespace-cdn.com/content/v1/59ebf554edaed825d0d8e200/1509139414651-0ALE6RUUXA0KSH49GC2E/CMvGhstWcAAYS8z.jpg" ><img src="/images/blog/CMvGhstWcAAYS8z.jpg" alt="Ultimaker Unboxed!"/></a> Ultimaker Unboxed![/caption] 
+       [caption id="" align="alignnone" width="599"]<a href="http://images.squarespace-cdn.com/content/v1/59ebf554edaed825d0d8e200/1509139414651-0ALE6RUUXA0KSH49GC2E/CMvGhstWcAAYS8z.jpg" ><img src="/makerlab/images/blog/CMvGhstWcAAYS8z.jpg" alt="Ultimaker Unboxed!"/></a> Ultimaker Unboxed![/caption] 
   
 
 

--- a/blog/wetherosies.html
+++ b/blog/wetherosies.html
@@ -110,7 +110,7 @@
   
 
   
-   <img src="/images/blog/Image_May_16__2018_8_25_34_AM.jpg" />
+   <img src="/makerlab/images/blog/Image_May_16__2018_8_25_34_AM.jpg" />
   
 
   

--- a/blog/will-3d-printing-revolutionize-architecture.html
+++ b/blog/will-3d-printing-revolutionize-architecture.html
@@ -107,11 +107,11 @@
   
 
   
-   <img src="/images/blog/03_Copley.FMU_.jpg" />
+   <img src="/makerlab/images/blog/03_Copley.FMU_.jpg" />
   
 
   
-   <img src="/images/blog/04_Copley.Components.jpg" />
+   <img src="/makerlab/images/blog/04_Copley.Components.jpg" />
   
 
   
@@ -119,7 +119,7 @@
   
 
   
-   <img src="/images/blog/06_3D.Process.jpg" />
+   <img src="/makerlab/images/blog/06_3D.Process.jpg" />
   
 
   

--- a/blog/wood-printing-at-the-lab.html
+++ b/blog/wood-printing-at-the-lab.html
@@ -76,11 +76,11 @@
   
 
   
-   <img src="/images/blog/Bottle-Openers.jpg" />
+   <img src="/makerlab/images/blog/Bottle-Openers.jpg" />
   
 
   
-   <img src="/images/blog/Hearts.jpg" />
+   <img src="/makerlab/images/blog/Hearts.jpg" />
   
 
 </div>
@@ -116,7 +116,7 @@
 <div class="image-gallery-wrapper">
 
   
-   <img src="/images/blog/Groot-1-1.jpg" />
+   <img src="/makerlab/images/blog/Groot-1-1.jpg" />
   
 
   

--- a/certificate.html
+++ b/certificate.html
@@ -66,7 +66,7 @@
 
 
   
-      <img src="/images/general/Snapseed_2.jpg" alt=""/>
+      <img src="/makerlab/images/general/Snapseed_2.jpg" alt=""/>
   
 
 

--- a/free-print-wednesday.html
+++ b/free-print-wednesday.html
@@ -37,7 +37,7 @@
       <div class="container">
         <div class="content-area">
           <h1>Free Print Wednesdays</h1>
-          <a href="https://www.eventbrite.com/e/free-3d-printing-tickets-31186362249" ><img src="/images/general/free-stuff_jpg.gif" alt=""/></a>
+          <a href="https://www.eventbrite.com/e/free-3d-printing-tickets-31186362249" ><img src="/makerlab/images/general/free-stuff_jpg.gif" alt=""/></a>
   
 
 
@@ -71,7 +71,7 @@
 
 
   
-       [caption id="" align="alignnone" width="600"]<img src="/images/general/Ultimakers-Lab.jpg" alt=" All new Ultimaker 2 printers in the Makerlab "/>  All new Ultimaker 2 printers in the Makerlab [/caption]
+       [caption id="" align="alignnone" width="600"]<img src="/makerlab/images/general/Ultimakers-Lab.jpg" alt=" All new Ultimaker 2 printers in the Makerlab "/>  All new Ultimaker 2 printers in the Makerlab [/caption]
         </div>
       </div>
     </div>

--- a/index.html
+++ b/index.html
@@ -69,7 +69,7 @@
           <!-- News Item 1 -->
           <div class="card">
             <a href="https://makerlab.illinois.edu/blog/2020/11/11/illinois-makerlab-collaboration-with-makers-for-covid-19">
-              <img src="/images/general/IMG_8347.jpg" alt="Makers for COVID-19" class="card-image"/>
+              <img src="/makerlab/images/general/IMG_8347.jpg" alt="Makers for COVID-19" class="card-image"/>
             </a>
             <div class="card-content">
               <h3 class="card-title">
@@ -83,7 +83,7 @@
           <!-- News Item 2 -->
           <div class="card">
             <a href="https://makerlab.illinois.edu/blog/2020/8/20/illinois-makerlab-launches-1-to-1-virtual-tutoring">
-              <img src="/images/general/wheel.PNG" alt="Virtual Tutoring" class="card-image"/>
+              <img src="/makerlab/images/general/wheel.PNG" alt="Virtual Tutoring" class="card-image"/>
             </a>
             <div class="card-content">
               <h3 class="card-title">
@@ -97,7 +97,7 @@
           <!-- News Item 3 -->
           <a href="/makerlab/blog/illinois-makerlab-collaborated-with-thera-solutions-functionalhand.html" class="news-card">
             <div class="news-card-image">
-              <img src="https://images.squarespace-cdn.com/content/v1/59ebf554edaed825d0d8e200/1596949071977-MDPKCE2IMKBFSCGL65CF/Henry+with+Functional+Hand-2.jpg?format=original" alt="Functional Hand">
+              <img src="/makerlab/images/blog/Henry_with_Functional_Hand-20.jpg" alt="Functional Hand">
             </div>
             <h3 class="news-card-title">ILLINOIS MAKERLAB X FUNCTIONAL HAND</h3>
           </a>
@@ -116,7 +116,7 @@
             <div class="slide" data-type="image" data-animation-role="image">
               <div class="margin-wrapper">
                 <a href="https://www.instagram.com/p/CLTDNYFLLkA/" class="image-slide-anchor content-fill">
-                  <noscript><img src="/images/general/image_d68c9fbc24a7.jpeg" alt="Need something to hold your phone up? Check out these cute prints that you can make at the Illinois MakerLab! Stop by and print one out! #3dprinting #animals" /></noscript><img class="thumb-image" elementtiming="system-gallery-block-grid" src="/images/general/image_d68c9fbc24a7.jpeg" data-image="/images/general/image_d68c9fbc24a7.jpeg" data-image-dimensions="674x476" data-image-focal-point="0.5,0.5" alt="Need something to hold your phone up? Check out these cute prints that you can make at the Illinois MakerLab! Stop by and print one out! #3dprinting #animals" data-load="false" data-image-id="6029f3dc2904a615b76d2ce9" data-type="image" />
+                  <noscript><img src="/makerlab/images/general/image_d68c9fbc24a7.jpeg" alt="Need something to hold your phone up? Check out these cute prints that you can make at the Illinois MakerLab! Stop by and print one out! #3dprinting #animals" /></noscript><img class="thumb-image" elementtiming="system-gallery-block-grid" src="/makerlab/images/general/image_d68c9fbc24a7.jpeg" data-image="/makerlab/images/general/image_d68c9fbc24a7.jpeg" data-image-dimensions="674x476" data-image-focal-point="0.5,0.5" alt="Need something to hold your phone up? Check out these cute prints that you can make at the Illinois MakerLab! Stop by and print one out! #3dprinting #animals" data-load="false" data-image-id="6029f3dc2904a615b76d2ce9" data-type="image" />
                 </a>
               </div>
             </div>
@@ -124,7 +124,7 @@
             <div class="slide" data-type="image" data-animation-role="image">
               <div class="margin-wrapper">
                 <a href="https://www.instagram.com/p/CLDrKwYLVUE/" class="image-slide-anchor content-fill">
-                  <noscript><img src="/images/general/image_25f38f0b7c19.jpeg" alt="Did you enjoy last nights Super Bowl? We sure did! Let&rsquo;s remember the memory with a 3D print. You can find this print on Thingiverse! Come to the lab to print one out for yourself or as a gift." /></noscript><img class="thumb-image" elementtiming="system-gallery-block-grid" src="/images/general/image_25f38f0b7c19.jpeg" data-image="/images/general/image_25f38f0b7c19.jpeg" data-image-dimensions="1440x1437" data-image-focal-point="0.5,0.5" alt="Did you enjoy last nights Super Bowl? We sure did! Let&rsquo;s remember the memory with a 3D print. You can find this print on Thingiverse! Come to the lab to print one out for yourself or as a gift." data-load="false" data-image-id="60220e20d6d3d8772dddf46a" data-type="image" />
+                  <noscript><img src="/makerlab/images/general/image_25f38f0b7c19.jpeg" alt="Did you enjoy last nights Super Bowl? We sure did! Let&rsquo;s remember the memory with a 3D print. You can find this print on Thingiverse! Come to the lab to print one out for yourself or as a gift." /></noscript><img class="thumb-image" elementtiming="system-gallery-block-grid" src="/makerlab/images/general/image_25f38f0b7c19.jpeg" data-image="/makerlab/images/general/image_25f38f0b7c19.jpeg" data-image-dimensions="1440x1437" data-image-focal-point="0.5,0.5" alt="Did you enjoy last nights Super Bowl? We sure did! Let&rsquo;s remember the memory with a 3D print. You can find this print on Thingiverse! Come to the lab to print one out for yourself or as a gift." data-load="false" data-image-id="60220e20d6d3d8772dddf46a" data-type="image" />
                 </a>
               </div>
             </div>
@@ -132,9 +132,9 @@
             <div class="slide" data-type="image" data-animation-role="image">
               <div class="margin-wrapper">
                 <a href="https://www.instagram.com/p/CKpCwXwrGLU/" class="image-slide-anchor content-fill">
-                  <noscript><img src="/images/general/image_7eaa4035b251.jpeg" alt="Hope everyone&rsquo;s first week went well! We will be OPEN this semester so check out our website for more info and to make a reservation!
+                  <noscript><img src="/makerlab/images/general/image_7eaa4035b251.jpeg" alt="Hope everyone&rsquo;s first week went well! We will be OPEN this semester so check out our website for more info and to make a reservation!
 
-**Safer Illinois Access is necessary due to our location being inside of the Business Instructional Facility " /></noscript><img class="thumb-image" elementtiming="system-gallery-block-grid" src="/images/general/image_7eaa4035b251.jpeg" data-image="/images/general/image_7eaa4035b251.jpeg" data-image-dimensions="1440x810" data-image-focal-point="0.5,0.5" alt="Hope everyone&rsquo;s first week went well! We will be OPEN this semester so check out our website for more info and to make a reservation!
+**Safer Illinois Access is necessary due to our location being inside of the Business Instructional Facility " /></noscript><img class="thumb-image" elementtiming="system-gallery-block-grid" src="/makerlab/images/general/image_7eaa4035b251.jpeg" data-image="/makerlab/images/general/image_7eaa4035b251.jpeg" data-image-dimensions="1440x810" data-image-focal-point="0.5,0.5" alt="Hope everyone&rsquo;s first week went well! We will be OPEN this semester so check out our website for more info and to make a reservation!
 
 **Safer Illinois Access is necessary due to our location being inside of the Business Instructional Facility " data-load="false" data-image-id="60147e0829015422fb6cdfd2" data-type="image" />
                 </a>
@@ -144,11 +144,11 @@
             <div class="slide" data-type="image" data-animation-role="image">
               <div class="margin-wrapper">
                 <a href="https://www.instagram.com/p/CJd23txrOcW/" class="image-slide-anchor content-fill">
-                  <noscript><img src="/images/general/image_9f7a8ec46d29.jpeg" alt="Soon we&rsquo;ll be saying goodbye to 2020 and hello to 2021!
+                  <noscript><img src="/makerlab/images/general/image_9f7a8ec46d29.jpeg" alt="Soon we&rsquo;ll be saying goodbye to 2020 and hello to 2021!
 
 Check out how our year went by clicking the link in our bio.
 
-We wish everyone a Happy New Year!" /></noscript><img class="thumb-image" elementtiming="system-gallery-block-grid" src="/images/general/image_9f7a8ec46d29.jpeg" data-image="/images/general/image_9f7a8ec46d29.jpeg" data-image-dimensions="661x661" data-image-focal-point="0.5,0.5" alt="Soon we&rsquo;ll be saying goodbye to 2020 and hello to 2021!
+We wish everyone a Happy New Year!" /></noscript><img class="thumb-image" elementtiming="system-gallery-block-grid" src="/makerlab/images/general/image_9f7a8ec46d29.jpeg" data-image="/makerlab/images/general/image_9f7a8ec46d29.jpeg" data-image-dimensions="661x661" data-image-focal-point="0.5,0.5" alt="Soon we&rsquo;ll be saying goodbye to 2020 and hello to 2021!
 
 Check out how our year went by clicking the link in our bio.
 
@@ -160,9 +160,9 @@ We wish everyone a Happy New Year!" data-load="false" data-image-id="5fedf7bafc5
             <div class="slide" data-type="image" data-animation-role="image">
               <div class="margin-wrapper">
                 <a href="https://www.instagram.com/p/CI1VK3LLGh0/" class="image-slide-anchor content-fill">
-                  <noscript><img src="/images/general/image_c9b86fabce68.jpeg" alt="The Illinois MakerLab wishes good luck to everyone with finals and happy holidays!
+                  <noscript><img src="/makerlab/images/general/image_c9b86fabce68.jpeg" alt="The Illinois MakerLab wishes good luck to everyone with finals and happy holidays!
 
-Here&rsquo;s a recent order made especially for Information Systems students (expect the gift in the mail 👀)" /></noscript><img class="thumb-image" elementtiming="system-gallery-block-grid" src="/images/general/image_c9b86fabce68.jpeg" data-image="/images/general/image_c9b86fabce68.jpeg" data-image-dimensions="1440x1080" data-image-focal-point="0.5,0.5" alt="The Illinois MakerLab wishes good luck to everyone with finals and happy holidays!
+Here&rsquo;s a recent order made especially for Information Systems students (expect the gift in the mail 👀)" /></noscript><img class="thumb-image" elementtiming="system-gallery-block-grid" src="/makerlab/images/general/image_c9b86fabce68.jpeg" data-image="/makerlab/images/general/image_c9b86fabce68.jpeg" data-image-dimensions="1440x1080" data-image-focal-point="0.5,0.5" alt="The Illinois MakerLab wishes good luck to everyone with finals and happy holidays!
 
 Here&rsquo;s a recent order made especially for Information Systems students (expect the gift in the mail 👀)" data-load="false" data-image-id="5fed7c5162bc8c231b031d15" data-type="image" />
                 </a>
@@ -172,9 +172,9 @@ Here&rsquo;s a recent order made especially for Information Systems students (ex
             <div class="slide" data-type="image" data-animation-role="image">
               <div class="margin-wrapper">
                 <a href="https://www.instagram.com/p/CIHCq4KrCbK/" class="image-slide-anchor content-fill">
-                  <noscript><img src="/images/general/image_2d087b9aa24d.jpeg" alt="Check out our recent blog post on how the Illinois MakerLab is giving back to the C-U Community with 3D printed PPE by partnering with Makers for COVID-19!
+                  <noscript><img src="/makerlab/images/general/image_2d087b9aa24d.jpeg" alt="Check out our recent blog post on how the Illinois MakerLab is giving back to the C-U Community with 3D printed PPE by partnering with Makers for COVID-19!
 
-Pictured is our volunteer Duncan Cleary dropping off Face Shields at the CU at Home Shelter t" /></noscript><img class="thumb-image" elementtiming="system-gallery-block-grid" src="/images/general/image_2d087b9aa24d.jpeg" data-image="/images/general/image_2d087b9aa24d.jpeg" data-image-dimensions="1010x797" data-image-focal-point="0.5,0.5" alt="Check out our recent blog post on how the Illinois MakerLab is giving back to the C-U Community with 3D printed PPE by partnering with Makers for COVID-19!
+Pictured is our volunteer Duncan Cleary dropping off Face Shields at the CU at Home Shelter t" /></noscript><img class="thumb-image" elementtiming="system-gallery-block-grid" src="/makerlab/images/general/image_2d087b9aa24d.jpeg" data-image="/makerlab/images/general/image_2d087b9aa24d.jpeg" data-image-dimensions="1010x797" data-image-focal-point="0.5,0.5" alt="Check out our recent blog post on how the Illinois MakerLab is giving back to the C-U Community with 3D printed PPE by partnering with Makers for COVID-19!
 
 Pictured is our volunteer Duncan Cleary dropping off Face Shields at the CU at Home Shelter t" data-load="false" data-image-id="5fed7c5162bc8c231b016" data-type="image" />
                 </a>
@@ -184,11 +184,11 @@ Pictured is our volunteer Duncan Cleary dropping off Face Shields at the CU at H
             <div class="slide" data-type="image" data-animation-role="image">
               <div class="margin-wrapper">
                 <a href="https://www.instagram.com/p/CHyOTaVLM4a/" class="image-slide-anchor content-fill">
-                  <noscript><img src="/images/general/image_215e8e6391c9.jpeg" alt="𝘞𝘩𝘢𝘵 𝘸𝘪𝘭𝘭 𝘺𝘰𝘶 𝘮𝘢𝘬𝘦?
+                  <noscript><img src="/makerlab/images/general/image_215e8e6391c9.jpeg" alt="𝘞𝘩𝘢𝘵 𝘸𝘪𝘭𝘭 𝘺𝘰𝘶 𝘮𝘢𝘬𝘦?
 
 Thank you Illini for stopping by the past few months and we hope you all have a great Fall Break! We will begin taking orders again after Fall Break.
 
-(From a recent order at the MakerLab)" /></noscript><img class="thumb-image" elementtiming="system-gallery-block-grid" src="/images/general/image_215e8e6391c9.jpeg" data-image="/images/general/image_215e8e6391c9.jpeg" data-image-dimensions="1440x1080" data-image-focal-point="0.5,0.5" alt="𝘞𝘩𝘢𝘵 𝘸𝘪𝘭𝘭 𝘺𝘰𝘶 𝘮𝘢𝘬𝘦?
+(From a recent order at the MakerLab)" /></noscript><img class="thumb-image" elementtiming="system-gallery-block-grid" src="/makerlab/images/general/image_215e8e6391c9.jpeg" data-image="/makerlab/images/general/image_215e8e6391c9.jpeg" data-image-dimensions="1440x1080" data-image-focal-point="0.5,0.5" alt="𝘞𝘩𝘢𝘵 𝘸𝘪𝘭𝘭 𝘺𝘰𝘶 𝘮𝘢𝘬𝘦?
 
 Thank you Illini for stopping by the past few months and we hope you all have a great Fall Break! We will begin taking orders again after Fall Break.
 
@@ -200,14 +200,14 @@ Thank you Illini for stopping by the past few months and we hope you all have a 
             <div class="slide" data-type="image" data-animation-role="image">
               <div class="margin-wrapper">
                 <a href="https://www.instagram.com/p/CHixvZ0sM5-/" class="image-slide-anchor content-fill">
-                  <noscript><img src="/images/general/image_356c0807c752.jpeg" alt="🚨IS IT TIME FOR A GIVEAWAY YET?🚨
+                  <noscript><img src="/makerlab/images/general/image_356c0807c752.jpeg" alt="🚨IS IT TIME FOR A GIVEAWAY YET?🚨
 oh yes, it definitely is! 🚧
 
 Illinois Makerlab is back with another exciting giveaway that you don&rsquo;t wanna miss...⚙️
 
 This exciting and personalised key chain can be yours if you follow these rules!🔮
 
-RULES " /></noscript><img class="thumb-image" elementtiming="system-gallery-block-grid" src="/images/general/image_356c0807c752.jpeg" data-image="/images/general/image_356c0807c752.jpeg" data-image-dimensions="720x720" data-image-focal-point="0.5,0.5" alt="🚨IS IT TIME FOR A GIVEAWAY YET?🚨
+RULES " /></noscript><img class="thumb-image" elementtiming="system-gallery-block-grid" src="/makerlab/images/general/image_356c0807c752.jpeg" data-image="/makerlab/images/general/image_356c0807c752.jpeg" data-image-dimensions="720x720" data-image-focal-point="0.5,0.5" alt="🚨IS IT TIME FOR A GIVEAWAY YET?🚨
 oh yes, it definitely is! 🚧
 
 Illinois Makerlab is back with another exciting giveaway that you don&rsquo;t wanna miss...⚙️

--- a/lab-staff.html
+++ b/lab-staff.html
@@ -117,11 +117,11 @@
   
 
   
-   <img src="/images/staff/zach.jpg" />
+   <img src="/makerlab/images/staff/zach.jpg" />
   
 
   
-   <img src="/images/staff/LAUREN6.jpeg" />
+   <img src="/makerlab/images/staff/LAUREN6.jpeg" />
   
 
   

--- a/makerlab-wrapped.html
+++ b/makerlab-wrapped.html
@@ -37,7 +37,7 @@
       <div class="container">
         <div class="content-area">
           <h1>2020 Wrapped</h1>
-          <img src="/images/general/Untitled.jpg" alt=""/>
+          <img src="/makerlab/images/general/Untitled.jpg" alt=""/>
   
 
 

--- a/online-ordering-1.html
+++ b/online-ordering-1.html
@@ -233,7 +233,7 @@
 
 
   
-      <img src="/images/general/Dual_Color_Block_I.JPG" alt=""/>
+      <img src="/makerlab/images/general/Dual_Color_Block_I.JPG" alt=""/>
   
 
 
@@ -307,7 +307,7 @@
 
 
   
-      <img src="/images/general/_Illinois150.JPG" alt=""/>
+      <img src="/makerlab/images/general/_Illinois150.JPG" alt=""/>
   
 
 
@@ -344,7 +344,7 @@
 
 
   
-      <img src="/images/general/Single_Color_Block_I.JPG" alt=""/>
+      <img src="/makerlab/images/general/Single_Color_Block_I.JPG" alt=""/>
   
 
 

--- a/online-ordering.html
+++ b/online-ordering.html
@@ -317,7 +317,7 @@
 
 
   
-      <img src="/images/general/Dual_Color_Block_I.JPG" alt=""/>
+      <img src="/makerlab/images/general/Dual_Color_Block_I.JPG" alt=""/>
   
 
 
@@ -391,7 +391,7 @@
 
 
   
-      <img src="/images/general/_Illinois150.JPG" alt=""/>
+      <img src="/makerlab/images/general/_Illinois150.JPG" alt=""/>
   
 
 
@@ -428,7 +428,7 @@
 
 
   
-      <img src="/images/general/Single_Color_Block_I.JPG" alt=""/>
+      <img src="/makerlab/images/general/Single_Color_Block_I.JPG" alt=""/>
   
 
 

--- a/online-summer-camps-2021.html
+++ b/online-summer-camps-2021.html
@@ -120,7 +120,7 @@
 
 
   
-      <a href="https://www.eventbrite.com/e/143551463291" ><img src="/images/summer/3.png" alt=""/></a>
+      <a href="https://www.eventbrite.com/e/143551463291" ><img src="/makerlab/images/summer/3.png" alt=""/></a>
   
 
 
@@ -242,7 +242,7 @@
 
 
   
-      <a href="https://www.eventbrite.com/e/143551342931" ><img src="/images/summer/3.png" alt=""/></a>
+      <a href="https://www.eventbrite.com/e/143551342931" ><img src="/makerlab/images/summer/3.png" alt=""/></a>
   
 
 

--- a/partners.html
+++ b/partners.html
@@ -70,11 +70,11 @@
 <div class="image-gallery-wrapper">
 
   
-   <img src="/images/general/All_new_Ultimaker_2_printers_in_the_MakerLab.jpg" />
+   <img src="/makerlab/images/general/All_new_Ultimaker_2_printers_in_the_MakerLab.jpg" />
   
 
   
-   <img src="/images/general/Dual_Color_Ultimaker_3_Printers.jpg" />
+   <img src="/makerlab/images/general/Dual_Color_Ultimaker_3_Printers.jpg" />
   
 
 </div>

--- a/practicum.html
+++ b/practicum.html
@@ -75,7 +75,7 @@
   
 
   
-   <img src="/images/general/Basic_3D_Printing.jpg" />
+   <img src="/makerlab/images/general/Basic_3D_Printing.jpg" />
   
 
   
@@ -83,7 +83,7 @@
   
 
   
-   <img src="/images/general/Ultimaker3-3.jpg" />
+   <img src="/makerlab/images/general/Ultimaker3-3.jpg" />
   
 
   

--- a/pricingservices.html
+++ b/pricingservices.html
@@ -40,11 +40,11 @@
           <div class="image-gallery-wrapper">
 
   
-   <img src="/images/general/Carabiners.jpg" />
+   <img src="/makerlab/images/general/Carabiners.jpg" />
   
 
   
-   <img src="/images/general/Ribs-2.jpg" />
+   <img src="/makerlab/images/general/Ribs-2.jpg" />
   
 
   

--- a/resources.html
+++ b/resources.html
@@ -71,11 +71,11 @@
   
 
   
-   <img src="/images/general/Digital-Making-Week-10-2.jpg" />
+   <img src="/makerlab/images/general/Digital-Making-Week-10-2.jpg" />
   
 
   
-   <img src="/images/general/Minecraft-3D-Printing.jpg" />
+   <img src="/makerlab/images/general/Minecraft-3D-Printing.jpg" />
   
 
   
@@ -83,7 +83,7 @@
   
 
   
-   <img src="/images/general/Mini-Figures.jpg" />
+   <img src="/makerlab/images/general/Mini-Figures.jpg" />
   
 
   
@@ -91,15 +91,15 @@
   
 
   
-   <img src="/images/general/Valentines-Day-2.jpg" />
+   <img src="/makerlab/images/general/Valentines-Day-2.jpg" />
   
 
   
-   <img src="/images/general/Hippo.jpg" />
+   <img src="/makerlab/images/general/Hippo.jpg" />
   
 
   
-   <img src="/images/general/Build-Max-10.jpg" />
+   <img src="/makerlab/images/general/Build-Max-10.jpg" />
   
 
 </div>
@@ -135,27 +135,27 @@
 <div class="image-gallery-wrapper">
 
   
-   <img src="/images/blog/ShivaniPatel-1.jpg" />
+   <img src="/makerlab/images/blog/ShivaniPatel-1.jpg" />
   
 
   
-   <img src="/images/blog/Skull-1.jpg" />
+   <img src="/makerlab/images/blog/Skull-1.jpg" />
   
 
   
-   <img src="/images/general/Order-Online-e1487546902493.jpg" />
+   <img src="/makerlab/images/general/Order-Online-e1487546902493.jpg" />
   
 
   
-   <img src="/images/general/Carabiners.jpg" />
+   <img src="/makerlab/images/general/Carabiners.jpg" />
   
 
   
-   <img src="/images/blog/Dragon-Box.jpg" />
+   <img src="/makerlab/images/blog/Dragon-Box.jpg" />
   
 
   
-   <img src="/images/blog/reese.jpeg" />
+   <img src="/makerlab/images/blog/reese.jpeg" />
   
 
   
@@ -163,11 +163,11 @@
   
 
   
-   <img src="/images/general/Ribs-2.jpg" />
+   <img src="/makerlab/images/general/Ribs-2.jpg" />
   
 
   
-   <img src="/images/general/Birthday-Card-1.jpg" />
+   <img src="/makerlab/images/general/Birthday-Card-1.jpg" />
   
 
 </div>

--- a/summer-2020-response.html
+++ b/summer-2020-response.html
@@ -94,11 +94,11 @@
 <div class="image-gallery-wrapper">
 
   
-   <img src="/images/blog/Screenshot_20200401-103435.png" />
+   <img src="/makerlab/images/blog/Screenshot_20200401-103435.png" />
   
 
   
-   <img src="/images/summer/图像_2020年4月13日_下午9_36_11.jpg" />
+   <img src="/makerlab/images/summer/图像_2020年4月13日_下午9_36_11.jpg" />
   
 
   
@@ -106,7 +106,7 @@
   
 
   
-   <img src="/images/summer/图像_2020年4月13日_下午9_35_50.jpg" />
+   <img src="/makerlab/images/summer/图像_2020年4月13日_下午9_35_50.jpg" />
   
 
   
@@ -114,7 +114,7 @@
   
 
   
-   <img src="/images/summer/图像_2020年4月13日_下午9_35_21.jpg" />
+   <img src="/makerlab/images/summer/图像_2020年4月13日_下午9_35_21.jpg" />
   
 
   
@@ -205,7 +205,7 @@
 
 
   
-      <img src="/images/blog/IMG_2601.jpg" alt=""/>
+      <img src="/makerlab/images/blog/IMG_2601.jpg" alt=""/>
   
 
 

--- a/summer.html
+++ b/summer.html
@@ -71,7 +71,7 @@
 
 
   
-      <a href="https://www.eventbrite.com/e/adventures-in-3d-modeling-and-design-with-tinkercad-2024-summer-camp-tickets-882363812917"  target="_blank" ><img src="/images/summer/tinkercad.PNG" alt=""/></a>
+      <a href="https://www.eventbrite.com/e/adventures-in-3d-modeling-and-design-with-tinkercad-2024-summer-camp-tickets-882363812917"  target="_blank" ><img src="/makerlab/images/summer/tinkercad.PNG" alt=""/></a>
   
 
 
@@ -145,7 +145,7 @@
 
 
   
-      <a href="https://www.eventbrite.com/e/illinois-makerlab-2024-summer-camp-minecraft-week-long-tickets-571120214937"  target="_blank" ><img src="/images/summer/UIMAKERLABminecraft.PNG" alt=""/></a>
+      <a href="https://www.eventbrite.com/e/illinois-makerlab-2024-summer-camp-minecraft-week-long-tickets-571120214937"  target="_blank" ><img src="/makerlab/images/summer/UIMAKERLABminecraft.PNG" alt=""/></a>
   
 
 
@@ -182,7 +182,7 @@
 
 
   
-      <img src="/images/summer/summer_camps.png" alt=""/>
+      <img src="/makerlab/images/summer/summer_camps.png" alt=""/>
   
 
 

--- a/summer/adventures-in-3d-modeling-and-printing.html
+++ b/summer/adventures-in-3d-modeling-and-printing.html
@@ -67,7 +67,7 @@
 <div class="image-gallery-wrapper">
 
   
-   <img src="/images/summer/Adventure_into_3D_Modeling-1.png" />
+   <img src="/makerlab/images/summer/Adventure_into_3D_Modeling-1.png" />
   
 
   

--- a/workshops.html
+++ b/workshops.html
@@ -233,7 +233,7 @@
 
 
   
-      <a href="https://www.eventbrite.com/cc/3d-design-with-fusion-360-1783719" ><img src="/images/summer/3.png" alt=""/></a>
+      <a href="https://www.eventbrite.com/cc/3d-design-with-fusion-360-1783719" ><img src="/makerlab/images/summer/3.png" alt=""/></a>
   
 
 


### PR DESCRIPTION
After the Squarespace CDN migration, image paths were set to /images/* but GitHub Pages subdirectory hosting requires /makerlab/images/* prefix.

Updated all image src and data-image attributes across:
- Homepage (index.html)
- 15 root-level HTML pages
- 291+ blog posts
- Summer camp pages

All 327 locally-hosted images now have correct paths and will load properly on GitHub Pages at vishalsachdev.github.io/makerlab/

Fixes broken images reported on homepage and throughout the site.